### PR TITLE
Fixed spec file on bare word comparison

### DIFF
--- a/package/python-kiwi_boxed_plugin-spec-template
+++ b/package/python-kiwi_boxed_plugin-spec-template
@@ -48,7 +48,7 @@ Release:        0
 Url:            https://github.com/OSInside/kiwi-boxed-plugin
 Summary:        KIWI - Boxed Build Plugin
 License:        GPL-3.0-or-later
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 # Needed to set Maintainer in output debs
 Packager:       Marcus Schaefer <ms@suse.de>
 %endif


### PR DESCRIPTION
on e.g Fedora Rawhide rpm complains about bare word comparison
error: bare words are no longer supported, please use "..."
This patch fixes the spec template to respect this