### PR TITLE
Setup pixz as default in SUSE box

### DIFF
--- a/boxes/suse/appliance.kiwi
+++ b/boxes/suse/appliance.kiwi
@@ -55,6 +55,7 @@
         <package name="gfxboot"/>
         <package name="dracut-kiwi-oem-repart"/>
         <package name="dracut-kiwi-oem-dump"/>
+        <package name="pixz"/>
     </packages>
     <packages type="bootstrap">
         <package name="udev"/>

--- a/boxes/suse/config.sh
+++ b/boxes/suse/config.sh
@@ -50,3 +50,8 @@ systemctl disable lvm2-lvmetad
 systemctl mask lvm2-lvmetad
 systemctl disable lvm2-lvmetad.socket
 systemctl mask lvm2-lvmetad.socket
+
+#======================================
+# Brute force replace xz with pixz
+#--------------------------------------
+cp /usr/bin/pixz /usr/bin/xz


### PR DESCRIPTION
Compression is one of the bottle necks that takes time.
Using all cores of the system via pixz speeds up the
build. As we are in a box the nasty binary replacement
should be acceptable