### PR TITLE
Added --no-snapshot option

### DIFF
--- a/boxes/fedora/root/usr/local/bin/run_kiwi
+++ b/boxes/fedora/root/usr/local/bin/run_kiwi
@@ -26,6 +26,8 @@ while true;do
     sleep "${sleep_timeout}"
 done
 
+rm -rf /result
+
 options=$(cut -f2 -d\" /proc/cmdline)
 options="${options} --description /description --target-dir /result"
 logfile=/bundle/result.log

--- a/boxes/suse/root/bin/run_kiwi
+++ b/boxes/suse/root/bin/run_kiwi
@@ -26,6 +26,8 @@ while true;do
     sleep "${sleep_timeout}"
 done
 
+rm -rf /result
+
 options=$(cut -f2 -d\" /proc/cmdline)
 options="${options} --description /description --target-dir /result"
 logfile=/bundle/result.log

--- a/boxes/ubuntu/root/usr/local/bin/run_kiwi
+++ b/boxes/ubuntu/root/usr/local/bin/run_kiwi
@@ -26,6 +26,8 @@ while true;do
     sleep "${sleep_timeout}"
 done
 
+rm -rf /result
+
 options=$(cut -f2 -d\" /proc/cmdline)
 options="${options} --description /description --target-dir /result"
 logfile=/bundle/result.log

--- a/kiwi_boxed_plugin/box_build.py
+++ b/kiwi_boxed_plugin/box_build.py
@@ -41,7 +41,10 @@ class BoxBuild:
         self.arch = arch or platform.machine()
         self.box = BoxDownload(boxname, arch)
 
-    def run(self, kiwi_build_command, update_check=True, keep_open=False):
+    def run(
+        self, kiwi_build_command, update_check=True,
+        snapshot=True, keep_open=False
+    ):
         """
         Start the build process in a box VM using KVM
 
@@ -57,6 +60,7 @@ class BoxBuild:
                 ]
 
         :param bool update_check: check for box updates True|False
+        :param bool snapshot: run box in snapshot mode True|False
         :param bool keep_open: keep VM running True|False
         """
         self.kiwi_build_command = kiwi_build_command
@@ -80,7 +84,7 @@ class BoxBuild:
         ] + Defaults.get_qemu_generic_setup() + [
             '-kernel', vm_setup.kernel,
             '-append', '"{0}"'.format(' '.join(vm_append))
-        ] + Defaults.get_qemu_storage_setup(vm_setup.system) + \
+        ] + Defaults.get_qemu_storage_setup(vm_setup.system, snapshot) + \
             Defaults.get_qemu_network_setup() + \
             Defaults.get_qemu_console_setup() + \
             Defaults.get_qemu_shared_path_setup(0, desc, 'kiwidescription') + \

--- a/kiwi_boxed_plugin/defaults.py
+++ b/kiwi_boxed_plugin/defaults.py
@@ -73,10 +73,10 @@ class Defaults:
         ]
 
     @staticmethod
-    def get_qemu_storage_setup(image_file):
+    def get_qemu_storage_setup(image_file, snapshot=True):
         return [
             '-drive',
-            'file={0},if=virtio,driver=qcow2,cache=off,snapshot=on'.format(
-                image_file
+            'file={0},if=virtio,driver=qcow2,cache=off,snapshot={1}'.format(
+                image_file, 'on' if snapshot else 'off'
             )
         ]

--- a/kiwi_boxed_plugin/tasks/system_boxbuild.py
+++ b/kiwi_boxed_plugin/tasks/system_boxbuild.py
@@ -21,6 +21,7 @@ usage: kiwi-ng system boxbuild -h | --help
            [--box-memory=<vmgb>]
            [--box-debug]
            [--no-update-check]
+           [--no-snapshot]
            [--x86_64]
            <kiwi_build_command_args>...
        kiwi-ng system boxbuild --list-boxes
@@ -45,6 +46,18 @@ options:
     --no-update-check
         Skip check for available box update. The option has no
         effect if the selected box does not yet exist on the host.
+
+    --no-snapshot
+        Run box with snapshot mode switched off. This causes the
+        box disk file to be modified by the build process and allows
+        to keep a persistent package cache as part of the box.
+        The option can be used to increase the build performance
+        due to data stored in the box which doesn't have to be
+        reloaded from the network. On the contrary this option
+        invalidates the immutable box attribute and should be
+        used with care. On update of the box all data stored
+        will be wiped. To prevent this combine the option with
+        the --no-update-check option.
 
     --x86_64
         Select box for the x86_64 architecture. If no architecture
@@ -88,6 +101,9 @@ class SystemBoxbuildTask(CliTask):
             request_update_check = not self.command_args.get(
                 '--no-update-check'
             )
+            request_snapshot_mode = not self.command_args.get(
+                '--no-snapshot'
+            )
             keep_open = self.command_args.get('--box-debug')
             box_build = BoxBuild(
                 boxname=self.command_args.get('--box'),
@@ -97,6 +113,7 @@ class SystemBoxbuildTask(CliTask):
             box_build.run(
                 self._validate_kiwi_build_command(),
                 request_update_check,
+                request_snapshot_mode,
                 keep_open
             )
 

--- a/test/unit/tasks/system_boxbuild_test.py
+++ b/test/unit/tasks/system_boxbuild_test.py
@@ -67,5 +67,5 @@ class TestSystemBoxbuildTask:
             [
                 '--type', 'vmx', '--profile', 'foo', 'system', 'build',
                 '--description', 'foo', '--target-dir', 'xxx'
-            ], True, False
+            ], True, True, False
         )


### PR DESCRIPTION
Run box with snapshot mode switched off. This causes the
box disk file to be modified by the build process and allows
to keep a persistent package cache as part of the box.
The option can be used to increase the build performance
due to data stored in the box which doesn't have to be
reloaded from the network. On the contrary this option
invalidates the immutable box attribute and should be
used with care. On update of the box all data stored
will be wiped. To prevent this combine the option with
the --no-update-check option.