### PR TITLE
Switch update check to .report file

### DIFF
--- a/kiwi_boxed_plugin/config/kiwi_boxed_plugin.yml
+++ b/kiwi_boxed_plugin/config/kiwi_boxed_plugin.yml
@@ -11,7 +11,7 @@ box:
         cmdline:
           - rd.plymouth=0
         source: obs://Virtualization:Appliances:SelfContained:suse/images
-        packages_file: SUSE-Box.x86_64-1.42.1-System-BuildBox.packages
+        packages_file: SUSE-Box.x86_64-1.42.1-System-BuildBox.report
         boxfiles:
           - SUSE-Box.x86_64-1.42.1-Kernel-BuildBox.tar.xz
           - SUSE-Box.x86_64-1.42.1-System-BuildBox.qcow2
@@ -30,7 +30,7 @@ box:
           - rd.plymouth=0
           - selinux=0
         source: obs://Virtualization:Appliances:SelfContained:fedora/images
-        packages_file: Fedora-Box.x86_64-1.1.2-System-BuildBox.packages
+        packages_file: Fedora-Box.x86_64-1.1.2-System-BuildBox.report
         boxfiles:
           - Fedora-Box.x86_64-1.1.2-Kernel-BuildBox.tar.xz
           - Fedora-Box.x86_64-1.1.2-System-BuildBox.qcow2
@@ -49,7 +49,7 @@ box:
           - rd.plymouth=0
           - selinux=0
         source: obs://Virtualization:Appliances:SelfContained:ubuntu/images
-        packages_file: Ubuntu-Box.x86_64-1.20.4-System-BuildBox.packages
+        packages_file: Ubuntu-Box.x86_64-1.20.4-System-BuildBox.report
         boxfiles:
           - Ubuntu-Box.x86_64-1.20.4-Kernel-BuildBox.tar.xz
           - Ubuntu-Box.x86_64-1.20.4-System-BuildBox.qcow2

--- a/test/data/kiwi_boxed_plugin.yml
+++ b/test/data/kiwi_boxed_plugin.yml
@@ -11,7 +11,7 @@ box:
         cmdline:
           - rd.plymouth=0
         source: obs://Virtualization:Appliances:SelfContained:suse/images
-        packages_file: SUSE-Box.x86_64-1.42.1-System-BuildBox.packages
+        packages_file: SUSE-Box.x86_64-1.42.1-System-BuildBox.report
         boxfiles:
           - SUSE-Box.x86_64-1.42.1-Kernel-BuildBox.tar.xz
           - SUSE-Box.x86_64-1.42.1-System-BuildBox.qcow2

--- a/test/unit/box_build_test.py
+++ b/test/unit/box_build_test.py
@@ -28,7 +28,7 @@ class TestBoxBuild:
     def test_run(self, mock_path_create, mock_os_system, mock_os_environ):
         self.build.run(
             [
-                '--type', 'vmx', 'system', 'build',
+                '--type', 'oem', 'system', 'build',
                 '--description', 'desc', '--target-dir', 'target'
             ],
             keep_open=True
@@ -43,7 +43,7 @@ class TestBoxBuild:
             '-nodefaults '
             '-snapshot '
             '-kernel kernel '
-            '-append "append kiwi=\\"--type vmx system build\\" kiwi-no-halt" '
+            '-append "append kiwi=\\"--type oem system build\\" kiwi-no-halt" '
             '-drive file=system,if=virtio,driver=qcow2,cache=off,snapshot=on '
             '-netdev user,id=user0 '
             '-device virtio-net-pci,netdev=user0 '

--- a/test/unit/box_config_test.py
+++ b/test/unit/box_config_test.py
@@ -64,11 +64,11 @@ class TestBoxConfig:
 
     def test_get_box_packages_file(self):
         assert self.box_config.get_box_packages_file() == \
-            'SUSE-Box.x86_64-1.42.1-System-BuildBox.packages'
+            'SUSE-Box.x86_64-1.42.1-System-BuildBox.report'
 
     def test_get_box_packages_shasum_file(self):
         assert self.box_config.get_box_packages_shasum_file() == \
-            'SUSE-Box.x86_64-1.42.1-System-BuildBox.packages.sha256'
+            'SUSE-Box.x86_64-1.42.1-System-BuildBox.report.sha256'
 
     def test_get_box_files(self):
         assert self.box_config.get_box_files() == [

--- a/test/unit/box_download_test.py
+++ b/test/unit/box_download_test.py
@@ -52,11 +52,11 @@ class TestBoxDownload:
             assert self.box_stage.register.call_args_list == [
                 call(
                     '/var/tmp/kiwi/boxes/suse/'
-                    'SUSE-Box.x86_64-1.42.1-System-BuildBox.packages'
+                    'SUSE-Box.x86_64-1.42.1-System-BuildBox.report'
                 ),
                 call(
                     '/var/tmp/kiwi/boxes/suse/'
-                    'SUSE-Box.x86_64-1.42.1-System-BuildBox.packages.sha256'
+                    'SUSE-Box.x86_64-1.42.1-System-BuildBox.report.sha256'
                 ),
                 call(
                     '/var/tmp/kiwi/boxes/suse/'
@@ -73,7 +73,7 @@ class TestBoxDownload:
             file_handle.write.assert_called_once_with('sum')
             assert repo.download_from_repository.call_args_list == [
                 call(
-                    'SUSE-Box.x86_64-1.42.1-System-BuildBox.packages',
+                    'SUSE-Box.x86_64-1.42.1-System-BuildBox.report',
                     self.box_stage.register.return_value
                 ),
                 call(
@@ -127,7 +127,7 @@ class TestBoxDownload:
         mock_os_path_exist.return_value = True
         assert self.box.fetch(update_check=True) == self.result
         repo.download_from_repository.assert_called_once_with(
-            'SUSE-Box.x86_64-1.42.1-System-BuildBox.packages',
+            'SUSE-Box.x86_64-1.42.1-System-BuildBox.report',
             self.box_stage.register.return_value
         )
 

--- a/test/unit/plugin_config_test.py
+++ b/test/unit/plugin_config_test.py
@@ -46,7 +46,7 @@ class TestPluginConfig:
                             'obs://Virtualization:Appliances:SelfContained:'
                             'suse/images',
                         'packages_file':
-                            'SUSE-Box.x86_64-1.42.1-System-BuildBox.packages',
+                            'SUSE-Box.x86_64-1.42.1-System-BuildBox.report',
                         'boxfiles': [
                             'SUSE-Box.x86_64-1.42.1-Kernel-BuildBox.tar.xz',
                             'SUSE-Box.x86_64-1.42.1-System-BuildBox.qcow2'

--- a/test/unit/tasks/system_boxbuild_test.py
+++ b/test/unit/tasks/system_boxbuild_test.py
@@ -10,7 +10,7 @@ class TestSystemBoxbuildTask:
     def setup(self):
         sys.argv = [
             sys.argv[0],
-            '--profile', 'foo', '--type', 'vmx',
+            '--profile', 'foo', '--type', 'oem',
             'system', 'boxbuild',
             '--box', 'suse', '--box-memory', '4', '--',
             '--description', '../data/description',
@@ -65,7 +65,7 @@ class TestSystemBoxbuildTask:
         )
         box_build.run.assert_called_once_with(
             [
-                '--type', 'vmx', '--profile', 'foo', 'system', 'build',
+                '--type', 'oem', '--profile', 'foo', 'system', 'build',
                 '--description', 'foo', '--target-dir', 'xxx'
             ], True, True, False
         )


### PR DESCRIPTION
The obs service has changed the publisher to no longer
publish the kiwi generated .packages file. Instead obs
creates its own .report file. This commit changes the
plugin config to fetch the .report file