### PR TITLE
Bump the setuptools metadata to require kiwi >= 9.21.21

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ config = {
     'license' : 'GPLv3+',
     'install_requires': [
         'docopt',
-        'kiwi',
+        'kiwi>=9.21.21',
         'requests',
         'PyYAML',
         'cerberus'


### PR DESCRIPTION
This should have been done in c51f53c319c9a714f9441e127950c6e07d02d3e9,
but it was accidentally missed.