### PR TITLE
Fixup gitlab pipeline triggers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,9 @@
+.only-default: &only-default
+  only:
+    - branches
+  except:
+    - master
+
 stages:
   - test
   - release
@@ -10,8 +16,7 @@ variables:
 code_style:
   image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
   stage: test
-  only:
-    - branches
+  <<: *only-default
   script:
     - tox -e check
   cache:
@@ -22,8 +27,7 @@ code_style:
 unit_py36:
   image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
   stage: test
-  only:
-    - branches
+  <<: *only-default
   script:
     - export PYTHON=python3.6
     - tox -e unit_py3_6 "-n $(nproc)"
@@ -35,8 +39,7 @@ unit_py36:
 unit_py38:
   image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$FEDORA_BUILD
   stage: test
-  only:
-    - branches
+  <<: *only-default
   script:
     - export PYTHON=python3.8
     - tox -e unit_py3_8 "-n $(nproc)"


### PR DESCRIPTION
Run unit tests in branches only but not in master.
Run release only on tags. We create tags only in master
thus no further exceptions other than on tags should
be needed.