### PR TITLE
Allow custom host path to be shared with the box

### DIFF
--- a/kiwi_boxed_plugin/box_build.py
+++ b/kiwi_boxed_plugin/box_build.py
@@ -43,7 +43,8 @@ class BoxBuild:
 
     def run(
         self, kiwi_build_command, update_check=True,
-        snapshot=True, keep_open=False, kiwi_version=None
+        snapshot=True, keep_open=False, kiwi_version=None,
+        custom_shared_path=None
     ):
         """
         Start the build process in a box VM using KVM
@@ -80,6 +81,8 @@ class BoxBuild:
             vm_append.append('kiwi-no-halt')
         if kiwi_version:
             vm_append.append('kiwi-version=_{0}_'.format(kiwi_version))
+        if custom_shared_path:
+            vm_append.append('custom-mount=_{0}_'.format(custom_shared_path))
         vm_run = [
             'qemu-system-{0}'.format(self.arch),
             '-m', format(self.ram or vm_setup.ram)
@@ -91,6 +94,10 @@ class BoxBuild:
             Defaults.get_qemu_console_setup() + \
             Defaults.get_qemu_shared_path_setup(0, desc, 'kiwidescription') + \
             Defaults.get_qemu_shared_path_setup(1, target_dir, 'kiwibundle')
+        if custom_shared_path:
+            vm_run += Defaults.get_qemu_shared_path_setup(
+                2, custom_shared_path, 'custompath'
+            )
         if vm_setup.initrd:
             vm_run += ['-initrd', vm_setup.initrd]
         if vm_setup.smp:

--- a/kiwi_boxed_plugin/tasks/system_boxbuild.py
+++ b/kiwi_boxed_plugin/tasks/system_boxbuild.py
@@ -21,6 +21,7 @@ usage: kiwi-ng system boxbuild -h | --help
            [--box-memory=<vmgb>]
            [--box-debug]
            [--kiwi-version=<version>]
+           [--shared-path=<path>]
            [--no-update-check]
            [--no-snapshot]
            [--x86_64]
@@ -76,6 +77,11 @@ options:
         with this option, the change of the KIWI version will be
         permanently stored in the used box.
 
+    --shared-path=<path>
+        Optional host path to share with the box. The same path
+        as it is present on the host will also be available inside
+        of the box during build time.
+
     <kiwi_build_command_args>...
         List of command parameters as supported by the kiwi-ng
         build command. The information given here is passed
@@ -114,6 +120,7 @@ class SystemBoxbuildTask(CliTask):
             )
             keep_open = self.command_args.get('--box-debug')
             kiwi_version = self.command_args.get('--kiwi-version')
+            shared_path = self.command_args.get('--shared-path')
             box_build = BoxBuild(
                 boxname=self.command_args.get('--box'),
                 ram=self.command_args.get('--box-memory'),
@@ -124,7 +131,8 @@ class SystemBoxbuildTask(CliTask):
                 request_update_check,
                 request_snapshot_mode,
                 keep_open,
-                kiwi_version
+                kiwi_version,
+                shared_path
             )
 
     def _validate_kiwi_build_command(self):

--- a/test/unit/box_build_test.py
+++ b/test/unit/box_build_test.py
@@ -32,7 +32,8 @@ class TestBoxBuild:
                 '--description', 'desc', '--target-dir', 'target'
             ],
             keep_open=True,
-            kiwi_version='9.22.1'
+            kiwi_version='9.22.1',
+            custom_shared_path='/var/tmp/repos'
         )
         mock_path_create.assert_called_once_with('target')
         mock_os_system.assert_called_once_with(
@@ -45,7 +46,7 @@ class TestBoxBuild:
             '-snapshot '
             '-kernel kernel '
             '-append "append kiwi=\\"--type oem system build\\"'
-            ' kiwi-no-halt kiwi-version=_9.22.1_" '
+            ' kiwi-no-halt kiwi-version=_9.22.1_ custom-mount=_/var/tmp/repos_" '
             '-drive file=system,if=virtio,driver=qcow2,cache=off,snapshot=on '
             '-netdev user,id=user0 '
             '-device virtio-net-pci,netdev=user0 '
@@ -58,6 +59,9 @@ class TestBoxBuild:
             '-fsdev local,security_model=mapped,id=fsdev1,path=target '
             '-device virtio-9p-pci,id=fs1,fsdev=fsdev1,mount_tag='
             'kiwibundle '
+            '-fsdev local,security_model=mapped,id=fsdev2,path=/var/tmp/repos '
+            '-device virtio-9p-pci,id=fs2,fsdev=fsdev2,mount_tag='
+            'custompath '
             '-initrd initrd '
             '-smp 4'
         )

--- a/test/unit/tasks/system_boxbuild_test.py
+++ b/test/unit/tasks/system_boxbuild_test.py
@@ -26,6 +26,7 @@ class TestSystemBoxbuildTask:
         self.task.command_args['--box'] = None
         self.task.command_args['--box-debug'] = False
         self.task.command_args['--kiwi-version'] = None
+        self.task.command_args['--shared-path'] = None
         self.task.command_args['<kiwi_build_command_args>'] = [
             '--', '--description', 'foo',
             '--target-dir', 'xxx'
@@ -68,5 +69,5 @@ class TestSystemBoxbuildTask:
             [
                 '--type', 'oem', '--profile', 'foo', 'system', 'build',
                 '--description', 'foo', '--target-dir', 'xxx'
-            ], True, True, False, None
+            ], True, True, False, None, None
         )


### PR DESCRIPTION
Added new option --shared-path to allow sharing a custom host
path with the box during image build time. The feature can be
used to e.g access host local repos when building via boxbuild.
This Fixes #12