### PR TITLE
Enable the arm architecture in boxbuild

### DIFF
--- a/kiwi_boxed_plugin/box_config.py
+++ b/kiwi_boxed_plugin/box_config.py
@@ -18,7 +18,10 @@
 import platform
 
 from kiwi_boxed_plugin.plugin_config import PluginConfig
-from kiwi_boxed_plugin.exceptions import KiwiBoxPluginBoxNameError
+from kiwi_boxed_plugin.exceptions import (
+    KiwiBoxPluginBoxNameError,
+    KiwiBoxPluginArchNotFoundError
+)
 
 
 class BoxConfig:
@@ -49,9 +52,6 @@ class BoxConfig:
 
     def get_box_processors(self):
         return self.box_config.get('processors')
-
-    def get_box_root(self):
-        return self.box_config.get('root')
 
     def get_box_console(self):
         return self.box_config.get('console')
@@ -86,3 +86,6 @@ class BoxConfig:
         for box_arch in box_config.get('arch'):
             if box_arch.get('name') == arch:
                 return box_arch
+        raise KiwiBoxPluginArchNotFoundError(
+            f'No box configuration found for architecture: {arch}'
+        )

--- a/kiwi_boxed_plugin/box_download.py
+++ b/kiwi_boxed_plugin/box_download.py
@@ -16,6 +16,7 @@
 # along with kiwi-boxed-build.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import platform
 import logging
 from collections import namedtuple
 from kiwi_boxed_plugin.utils.dir_files import DirFiles
@@ -42,6 +43,7 @@ class BoxDownload:
     :param string arch: arch name for box
     """
     def __init__(self, boxname, arch=None):
+        self.arch = arch or platform.machine()
         self.box_config = BoxConfig(boxname, arch)
         self.box_dir = os.sep.join(
             [Defaults.get_local_box_cache_dir(), boxname]
@@ -131,8 +133,7 @@ class BoxDownload:
             system=self.system,
             kernel=self.kernel,
             initrd=self.initrd,
-            append='root={0} console={1} {2}'.format(
-                self.box_config.get_box_root(),
+            append='console={0} {1}'.format(
                 self.box_config.get_box_console(),
                 self.box_config.get_box_kernel_cmdline()
             ),
@@ -147,17 +148,19 @@ class BoxDownload:
     def _extract_kernel_from_tarball(self, tarfile):
         Command.run(
             [
-                'tar', '-C', self.box_dir, '--transform', 's/.*/kernel/',
+                'tar', '-C', self.box_dir,
+                '--transform', f's/.*/kernel.{self.arch}/',
                 '--wildcards', '-xf', tarfile, '*.kernel'
             ]
         )
-        return os.sep.join([self.box_dir, 'kernel'])
+        return os.sep.join([self.box_dir, f'kernel.{self.arch}'])
 
     def _extract_initrd_from_tarball(self, tarfile):
         Command.run(
             [
-                'tar', '-C', self.box_dir, '--transform', 's/.*/initrd/',
+                'tar', '-C', self.box_dir,
+                '--transform', f's/.*/initrd.{self.arch}/',
                 '--wildcards', '-xf', tarfile, '*.initrd.xz'
             ]
         )
-        return os.sep.join([self.box_dir, 'initrd'])
+        return os.sep.join([self.box_dir, f'initrd.{self.arch}'])

--- a/kiwi_boxed_plugin/config/kiwi_boxed_plugin.yml
+++ b/kiwi_boxed_plugin/config/kiwi_boxed_plugin.yml
@@ -3,12 +3,12 @@ box:
     name: suse
     mem_mb: 8096
     processors: 4
-    root: /dev/vda1
     console: hvc0
     arch:
       -
         name: x86_64
         cmdline:
+          - root=/dev/vda1
           - rd.plymouth=0
         source: obs://Virtualization:Appliances:SelfContained:suse/images
         packages_file: SUSE-Box.x86_64-1.42.1-System-BuildBox.report
@@ -21,12 +21,12 @@ box:
     name: leap
     mem_mb: 8096
     processors: 4
-    root: /dev/vda1
     console: hvc0
     arch:
       -
         name: x86_64
         cmdline:
+          - root=/dev/vda1
           - rd.plymouth=0
         source: obs://Virtualization:Appliances:SelfContained:leap/images
         packages_file: Leap-Box.x86_64-1.42.1-System-BuildBox.report
@@ -39,12 +39,12 @@ box:
     name: fedora
     mem_mb: 8096
     processors: 4
-    root: /dev/vda1
     console: hvc0
     arch:
       -
         name: x86_64
         cmdline:
+          - root=/dev/vda1
           - rd.plymouth=0
           - selinux=0
         source: obs://Virtualization:Appliances:SelfContained:fedora/images
@@ -58,12 +58,12 @@ box:
     name: ubuntu
     mem_mb: 8096
     processors: 4
-    root: /dev/vda1
     console: hvc0
     arch:
       -
         name: x86_64
         cmdline:
+          - root=/dev/vda1
           - rd.plymouth=0
           - selinux=0
         source: obs://Virtualization:Appliances:SelfContained:ubuntu/images
@@ -77,12 +77,12 @@ box:
     name: universal
     mem_mb: 8096
     processors: 4
-    root: /dev/vda1
     console: hvc0
     arch:
       -
         name: x86_64
         cmdline:
+          - root=/dev/vda3
           - rd.plymouth=0
           - selinux=0
         source: obs://Virtualization:Appliances:SelfContained:universal/images
@@ -90,4 +90,17 @@ box:
         boxfiles:
           - Universal-Box.x86_64-1.1.2-Kernel-BuildBox.tar.xz
           - Universal-Box.x86_64-1.1.2-System-BuildBox.qcow2
+        use_initrd: true
+
+      -
+        name: aarch64
+        cmdline:
+          - root=/dev/vda2
+          - rd.plymouth=0
+          - selinux=0
+        source: obs://Virtualization:Appliances:SelfContained:universal/images
+        packages_file: Universal-Box.aarch64-1.1.2-System-BuildBox.report
+        boxfiles:
+          - Universal-Box.aarch64-1.1.2-Kernel-BuildBox.tar.xz
+          - Universal-Box.aarch64-1.1.2-System-BuildBox.qcow2
         use_initrd: true

--- a/kiwi_boxed_plugin/defaults.py
+++ b/kiwi_boxed_plugin/defaults.py
@@ -44,8 +44,6 @@ class Defaults:
     @staticmethod
     def get_qemu_generic_setup():
         return [
-            '-machine', 'accel=kvm',
-            '-cpu', 'host',
             '-nographic',
             '-nodefaults',
             '-snapshot'

--- a/kiwi_boxed_plugin/exceptions.py
+++ b/kiwi_boxed_plugin/exceptions.py
@@ -34,3 +34,9 @@ class KiwiBoxPluginVirtioFsError(KiwiError):
     """
     Exception raised if virtiofsd does not start
     """
+
+
+class KiwiBoxPluginArchNotFoundError(KiwiError):
+    """
+    Exception raised if the selected architecture has no configuration
+    """

--- a/kiwi_boxed_plugin/plugin_config_schema.py
+++ b/kiwi_boxed_plugin/plugin_config_schema.py
@@ -20,11 +20,6 @@ schema = {
                     'required': False,
                     'empty': False
                 },
-                'root': {
-                    'type': 'string',
-                    'required': True,
-                    'empty': False
-                },
                 'console': {
                     'type': 'string',
                     'required': True,

--- a/kiwi_boxed_plugin/utils/dir_files.py
+++ b/kiwi_boxed_plugin/utils/dir_files.py
@@ -68,6 +68,10 @@ class DirFiles:
         fully atomic as it uses two move commands in a series
         """
         Path.create(self.dirname_tmp)
+        bash_command = [
+            'cp', '-a', f'{self.dirname}/*', self.dirname_tmp
+        ]
+        Command.run(['bash', '-c', ' '.join(bash_command)])
         for origin, tmpname in list(self.collection.items()):
             Command.run(
                 ['mv', tmpname, os.sep.join([self.dirname_tmp, origin])]

--- a/test/data/kiwi_boxed_plugin.yml
+++ b/test/data/kiwi_boxed_plugin.yml
@@ -3,16 +3,48 @@ box:
     name: suse
     mem_mb: 8096
     processors: 4
-    root: /dev/vda1
     console: hvc0
     arch:
       -
         name: x86_64
         cmdline:
+          - root=/dev/vda1
           - rd.plymouth=0
         source: obs://Virtualization:Appliances:SelfContained:suse/images
         packages_file: SUSE-Box.x86_64-1.42.1-System-BuildBox.report
         boxfiles:
           - SUSE-Box.x86_64-1.42.1-Kernel-BuildBox.tar.xz
           - SUSE-Box.x86_64-1.42.1-System-BuildBox.qcow2
+        use_initrd: true
+
+  -
+    name: universal
+    mem_mb: 8096
+    processors: 4
+    console: hvc0
+    arch:
+      -
+        name: x86_64
+        cmdline:
+          - root=/dev/vda3
+          - rd.plymouth=0
+          - selinux=0
+        source: obs://Virtualization:Appliances:SelfContained:universal/images
+        packages_file: Universal-Box.x86_64-1.1.2-System-BuildBox.report
+        boxfiles:
+          - Universal-Box.x86_64-1.1.2-Kernel-BuildBox.tar.xz
+          - Universal-Box.x86_64-1.1.2-System-BuildBox.qcow2
+        use_initrd: true
+
+      -
+        name: aarch64
+        cmdline:
+          - root=/dev/vda2
+          - rd.plymouth=0
+          - selinux=0
+        source: obs://Virtualization:Appliances:SelfContained:universal/images
+        packages_file: Universal-Box.aarch64-1.1.2-System-BuildBox.report
+        boxfiles:
+          - Universal-Box.aarch64-1.1.2-Kernel-BuildBox.tar.xz
+          - Universal-Box.aarch64-1.1.2-System-BuildBox.qcow2
         use_initrd: true

--- a/test/unit/box_download_test.py
+++ b/test/unit/box_download_test.py
@@ -22,9 +22,9 @@ class TestBoxDownload:
         self.result = self.box.vm_setup_type(
             system='/var/tmp/kiwi/boxes/suse/'
             'SUSE-Box.x86_64-1.42.1-System-BuildBox.qcow2',
-            kernel='/var/tmp/kiwi/boxes/suse/kernel',
-            initrd='/var/tmp/kiwi/boxes/suse/initrd',
-            append='root=/dev/vda1 console=hvc0 rd.plymouth=0',
+            kernel='/var/tmp/kiwi/boxes/suse/kernel.x86_64',
+            initrd='/var/tmp/kiwi/boxes/suse/initrd.x86_64',
+            append='console=hvc0 root=/dev/vda1 rd.plymouth=0',
             ram=8096,
             smp=4
         )
@@ -90,7 +90,7 @@ class TestBoxDownload:
                 call(
                     [
                         'tar', '-C', '/var/tmp/kiwi/boxes/suse',
-                        '--transform', 's/.*/kernel/',
+                        '--transform', 's/.*/kernel.x86_64/',
                         '--wildcards', '-xf',
                         '/var/tmp/kiwi/boxes/suse/'
                         'SUSE-Box.x86_64-1.42.1-Kernel-BuildBox.tar.xz',
@@ -100,7 +100,7 @@ class TestBoxDownload:
                 call(
                     [
                         'tar', '-C', '/var/tmp/kiwi/boxes/suse',
-                        '--transform', 's/.*/initrd/',
+                        '--transform', 's/.*/initrd.x86_64/',
                         '--wildcards', '-xf',
                         '/var/tmp/kiwi/boxes/suse/'
                         'SUSE-Box.x86_64-1.42.1-Kernel-BuildBox.tar.xz',

--- a/test/unit/plugin_config_test.py
+++ b/test/unit/plugin_config_test.py
@@ -29,19 +29,17 @@ class TestPluginConfig:
             PluginConfig()
 
     def test_get_config(self):
+        print(self.plugin_config.get_config())
         assert self.plugin_config.get_config() == [
             {
                 'name': 'suse',
                 'mem_mb': 8096,
                 'processors': 4,
-                'root': '/dev/vda1',
                 'console': 'hvc0',
                 'arch': [
                     {
                         'name': 'x86_64',
-                        'cmdline': [
-                            'rd.plymouth=0'
-                        ],
+                        'cmdline': ['root=/dev/vda1', 'rd.plymouth=0'],
                         'source':
                             'obs://Virtualization:Appliances:SelfContained:'
                             'suse/images',
@@ -50,6 +48,48 @@ class TestPluginConfig:
                         'boxfiles': [
                             'SUSE-Box.x86_64-1.42.1-Kernel-BuildBox.tar.xz',
                             'SUSE-Box.x86_64-1.42.1-System-BuildBox.qcow2'
+                        ],
+                        'use_initrd': True
+                    }
+                ]
+            },
+            {
+                'name': 'universal',
+                'mem_mb': 8096,
+                'processors': 4,
+                'console': 'hvc0',
+                'arch': [
+                    {
+                        'name': 'x86_64',
+                        'cmdline': [
+                            'root=/dev/vda3', 'rd.plymouth=0', 'selinux=0'
+                        ],
+                        'source':
+                            'obs://Virtualization:Appliances:SelfContained:'
+                            'universal/images',
+                        'packages_file':
+                            'Universal-Box.x86_64-1.1.2-System-BuildBox.report',
+                        'boxfiles': [
+                            'Universal-Box.x86_64-1.1.2-Kernel-BuildBox.tar.xz',
+                            'Universal-Box.x86_64-1.1.2-System-BuildBox.qcow2'
+                        ],
+                        'use_initrd': True
+                    },
+                    {
+                        'name': 'aarch64',
+                        'cmdline': [
+                            'root=/dev/vda2', 'rd.plymouth=0', 'selinux=0'
+                        ],
+                        'source':
+                            'obs://Virtualization:Appliances:SelfContained:'
+                            'universal/images',
+                        'packages_file': 'Universal-Box.'
+                            'aarch64-1.1.2-System-BuildBox.report',
+                        'boxfiles': [
+                            'Universal-Box.aarch64-1.1.2-'
+                            'Kernel-BuildBox.tar.xz',
+                            'Universal-Box.aarch64-1.1.2-'
+                            'System-BuildBox.qcow2'
                         ],
                         'use_initrd': True
                     }

--- a/test/unit/tasks/system_boxbuild_test.py
+++ b/test/unit/tasks/system_boxbuild_test.py
@@ -29,6 +29,8 @@ class TestSystemBoxbuildTask:
         self.task.command_args['--shared-path'] = None
         self.task.command_args['--9p-sharing'] = None
         self.task.command_args['--virtiofs-sharing'] = None
+        self.task.command_args['--cpu'] = None
+        self.task.command_args['--machine'] = None
         self.task.command_args['<kiwi_build_command_args>'] = [
             '--', '--description', 'foo',
             '--target-dir', 'xxx'
@@ -65,13 +67,42 @@ class TestSystemBoxbuildTask:
         mock_BoxBuild.return_value = box_build
         self.task.process()
         mock_BoxBuild.assert_called_once_with(
-            boxname='suse', ram=None, arch=None, sharing_backend='9p'
+            boxname='suse', ram=None, arch=None,
+            machine=None, cpu='host', sharing_backend='9p'
         )
         box_build.run.assert_called_once_with(
             [
                 '--type', 'oem', '--profile', 'foo', 'system', 'build',
                 '--description', 'foo', '--target-dir', 'xxx'
             ], True, True, False, None, None
+        )
+
+    @patch('kiwi_boxed_plugin.tasks.system_boxbuild.BoxBuild')
+    def test_process_system_boxbuild_for_x86_64(self, mock_BoxBuild):
+        self._init_command_args()
+        self.task.command_args['boxbuild'] = True
+        self.task.command_args['--box'] = 'suse'
+        self.task.command_args['--x86_64'] = True
+        box_build = Mock()
+        mock_BoxBuild.return_value = box_build
+        self.task.process()
+        mock_BoxBuild.assert_called_once_with(
+            boxname='suse', ram=None, arch='x86_64',
+            machine=None, cpu='host', sharing_backend='9p'
+        )
+
+    @patch('kiwi_boxed_plugin.tasks.system_boxbuild.BoxBuild')
+    def test_process_system_boxbuild_for_aarch64(self, mock_BoxBuild):
+        self._init_command_args()
+        self.task.command_args['boxbuild'] = True
+        self.task.command_args['--box'] = 'suse'
+        self.task.command_args['--aarch64'] = True
+        box_build = Mock()
+        mock_BoxBuild.return_value = box_build
+        self.task.process()
+        mock_BoxBuild.assert_called_once_with(
+            boxname='suse', ram=None, arch='aarch64',
+            machine=None, cpu='host', sharing_backend='9p'
         )
 
     @patch('kiwi_boxed_plugin.tasks.system_boxbuild.BoxBuild')
@@ -84,12 +115,14 @@ class TestSystemBoxbuildTask:
         mock_BoxBuild.return_value = box_build
         self.task.process()
         mock_BoxBuild.assert_called_once_with(
-            boxname='suse', ram=None, arch=None, sharing_backend='9p'
+            boxname='suse', ram=None, arch=None,
+            machine=None, cpu='host', sharing_backend='9p'
         )
         self.task.command_args['--9p-sharing'] = False
         self.task.command_args['--virtiofs-sharing'] = True
         mock_BoxBuild.reset_mock()
         self.task.process()
         mock_BoxBuild.assert_called_once_with(
-            boxname='suse', ram=None, arch=None, sharing_backend='virtiofs'
+            boxname='suse', ram=None, arch=None,
+            machine=None, cpu='host', sharing_backend='virtiofs'
         )

--- a/test/unit/utils/dir_files_test.py
+++ b/test/unit/utils/dir_files_test.py
@@ -30,6 +30,7 @@ class TestDirFiles:
         self.dir_manager.commit()
         mock_Path.create.assert_called_once_with('box_dir.tmp')
         assert mock_Command_run.call_args_list == [
+            call(['bash', '-c', 'cp -a box_dir/* box_dir.tmp']),
             call(['mv', 'tmp_a', 'box_dir.tmp/file_a']),
             call(['mv', 'box_dir', 'box_dir.wipe']),
             call(['mv', 'box_dir.tmp', 'box_dir']),


### PR DESCRIPTION
Add new options 

* --aarch64
*  --cpu 
* --machine

which allows to select and configure cross arch builds in particular for the arm architecture in this commit. A box build for aarch64 now exists for our users and can be used with the proposed changes.

To allow a cross arch build for arm on x86 the following command can be used:

```
$ kiwi-ng system boxbuild --box universal --cpu cortex-a57 --machine virt -- ...
```