### PR TITLE
Make sure man pages are part of sdist tarball

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ pypi_upload:
   script:
     - base64 --decode "$PYPI_CONFIG" > .pypirc
     - export PYTHON=python3.6
-    - tox -e release
+    - tox -e doc,release
   cache:
     key: "$CI_JOB_NAME"
     paths:


### PR DESCRIPTION
The current tarball when uploaded to pypi via gitlab does
not contain the manual pages because the doc target to build
them is not called.