### PR TITLE
Improve usage message regarding argument parsing

### DIFF
--- a/kiwi_boxed_plugin/tasks/system_boxbuild.py
+++ b/kiwi_boxed_plugin/tasks/system_boxbuild.py
@@ -28,13 +28,15 @@ usage: kiwi-ng system boxbuild -h | --help
            [--x86_64 | --aarch64]
            [--machine=<qemu_machine>]
            [--cpu=<qemu_cpu>]
-           <kiwi_build_command_args>...
+           -- <kiwi_build_command_args>...
        kiwi-ng system boxbuild --list-boxes
        kiwi-ng system boxbuild help
 
 commands:
     boxbuild
-        build a system image in a self contained virtual machine
+        build a system image in a self contained virtual machine,
+        where separator -- marks the start of arguments passed to
+        the build command.
 
 options:
     --box=<name>
@@ -108,7 +110,7 @@ options:
         cross arch builds it's required to specify the CPU
         emulation the box should use
 
-    <kiwi_build_command_args>...
+    -- <kiwi_build_command_args>...
         List of command parameters as supported by the kiwi-ng
         build command. The information given here is passed
         along to the kiwi-ng system build command running in


### PR DESCRIPTION
Provide better usage information to explain how the boxbuild
command differentiates between arguments for the boxbuild
command itself and arguments used for the build command that
runs inside of the box. This Fixes OSInside/kiwi#1779