### PR TITLE
Added more robust qemu binary lookup

### DIFF
--- a/kiwi_boxed_plugin/exceptions.py
+++ b/kiwi_boxed_plugin/exceptions.py
@@ -40,3 +40,10 @@ class KiwiBoxPluginArchNotFoundError(KiwiError):
     """
     Exception raised if the selected architecture has no configuration
     """
+
+
+class KiwiBoxPluginQEMUBinaryNotFound(KiwiError):
+    """
+    Exception raised if no QEMU binary for the desired architecture
+    could be found
+    """


### PR DESCRIPTION
Check for qemu-system-ARCH first. If this is missing check
for qemu-kvm if we are on the x86_64 architecture. If no
binary was found raise an exception. This Fixes #27