### PR TITLE
Added --box-smp-cpus option

### DIFF
--- a/doc/source/commands/system_boxbuild.rst
+++ b/doc/source/commands/system_boxbuild.rst
@@ -11,10 +11,17 @@ SYNOPSIS
    kiwi-ng system boxbuild -h | --help
    kiwi-ng system boxbuild --box=<name>
        [--box-memory=<vmgb>]
+       [--box-smp-cpus=<number>]
        [--box-debug]
+       [--kiwi-version=<version>]
+       [--shared-path=<path>]
        [--no-update-check]
-       [--x86_64]
-       <kiwi_build_command_args>...
+       [--no-snapshot]
+       [--9p-sharing | --virtiofs-sharing]
+       [--x86_64 | --aarch64]
+       [--machine=<qemu_machine>]
+       [--cpu=<qemu_cpu>]
+       -- <kiwi_build_command_args>...
    kiwi-ng system boxbuild --list-boxes
    kiwi-ng system boxbuild help
 
@@ -66,12 +73,36 @@ OPTIONS
   Number of GBs to reserve as main memory for the virtual
   machine. By default 8GB will be used.
 
+--box-smp-cpus=<number>
+
+  Number of CPUs to use in the SMP setup. By default
+  4 CPUs will be used
+
 --no-update-check
 
   Skip check for available box update. The option has no
   effect if the selected box does not yet exist on the host.
 
---x86_64
+--no-snapshot
+
+  Run box with snapshot mode switched off. This causes the
+  box disk file to be modified by the build process and allows
+  to keep a persistent package cache as part of the box.
+  The option can be used to increase the build performance
+  due to data stored in the box which doesn't have to be
+  reloaded from the network. On the contrary this option
+  invalidates the immutable box attribute and should be
+  used with care. On update of the box all data stored
+  will be wiped. To prevent this combine the option with
+  the --no-update-check option.
+
+--9p-sharing|--virtiofs-sharing
+
+  Select sharing backend to use for sharing data between the
+  host and the box. This can be either 9p or virtiofs. By
+  default 9p is used
+
+--x86_64|--aarch64
 
   Select box for the x86_64 architecture. If no architecture
   is selected the host architecture is used for selecting
@@ -82,13 +113,47 @@ OPTIONS
 
   In debug mode the started virtual machine will be kept open
 
-<kiwi_build_command_args>...
+--kiwi-version=<version>
 
-  List of command parameters as supported by the kiwi-ng
-  build command. The information given here is passed
-  along to the kiwi-ng system build command running in
-  the virtual machine. See the Example below how to provide
-  options to the build command correctly.
+  Specify a KIWI version to use for the build. The referenced
+  KIWI will be fetched from pip and replaces the box installed
+  KIWI version. Note: If --no-snapshot is used in combination
+  with this option, the change of the KIWI version will be
+  permanently stored in the used box.
+
+--shared-path=<path>
+
+  Optional host path to share with the box. The same path
+  as it is present on the host will also be available inside
+  of the box during build time.
+
+--machine=<qemu_machine>
+
+  Optional machine name used by QEMU. By default no specific
+  value is used here and qemu selects its default machine type.
+  For cross arch builds or for system architectures for which
+  QEMU defines no default like for Arm, it's required to specify
+  a machine name.
+
+  If you don’t care about reproducing the idiosyncrasies of
+  a particular bit of hardware, the best option is to use
+  the 'virt' machine type.
+
+--cpu=<qemu_cpu>
+
+  Optional CPU type used by QEMU. By default the host CPU
+  type is used which is only a good selection if the host
+  and the selected box are from the same architecture. On
+  cross arch builds it's required to specify the CPU
+  emulation the box should use
+
+-- <kiwi_build_command_args>...
+
+   List of command parameters as supported by the kiwi-ng
+   build command. The information given here is passed
+   along to the kiwi-ng system build command running in
+   the virtual machine. See the Example below how to provide
+   options to the build command correctly.
 
 EXAMPLE
 -------

--- a/kiwi_boxed_plugin/box_build.py
+++ b/kiwi_boxed_plugin/box_build.py
@@ -35,14 +35,20 @@ class BoxBuild:
     Implements an interface to run a kiwi build box using
     the KVM virtualization platform
 
-    :param string boxname: name of the box from kiwi_boxed_plugin.yml
-    :param string arch: arch name for box
+    :param str boxname: name of the box from kiwi_boxed_plugin.yml
+    :param str ram: amount of main memory to use for the box
+    :param str smp: number of CPUs to use in the SMP setup for the box
+    :param str arch: arch name for box
+    :param str machine: machine emulaton type for the box
+    :param str cpu: CPU emulation type
+    :param str sharing_backend: guest/host sharing backend type
     """
     def __init__(
-        self, boxname, ram=None, arch=None, machine=None,
+        self, boxname, ram=None, smp=None, arch=None, machine=None,
         cpu='host', sharing_backend='9p'
     ):
         self.ram = ram
+        self.smp = smp
         self.cpu = cpu
         self.machine = machine
         self.arch = arch or platform.machine()
@@ -132,7 +138,7 @@ class BoxBuild:
         if vm_setup.initrd:
             vm_run += ['-initrd', vm_setup.initrd]
         if vm_setup.smp:
-            vm_run += ['-smp', format(vm_setup.smp)]
+            vm_run += ['-smp', format(self.smp or vm_setup.smp)]
         os.environ['TMPDIR'] = Defaults.get_local_box_cache_dir()
         log.debug(
             'Set TMPDIR: {0}'.format(os.environ['TMPDIR'])

--- a/kiwi_boxed_plugin/tasks/system_boxbuild.py
+++ b/kiwi_boxed_plugin/tasks/system_boxbuild.py
@@ -19,6 +19,7 @@
 usage: kiwi-ng system boxbuild -h | --help
        kiwi-ng system boxbuild --box=<name>
            [--box-memory=<vmgb>]
+           [--box-smp-cpus=<number>]
            [--box-debug]
            [--kiwi-version=<version>]
            [--shared-path=<path>]
@@ -49,6 +50,10 @@ options:
     --box-memory=<vmgb>
         Number of GBs to reserve as main memory for the virtual
         machine. By default 8GB will be used.
+
+    --box-smp-cpus=<number>
+        Number of CPUs to use in the SMP setup. By default
+        4 CPUs will be used
 
     --no-update-check
         Skip check for available box update. The option has no
@@ -152,6 +157,7 @@ class SystemBoxbuildTask(CliTask):
             box_build = BoxBuild(
                 boxname=self.command_args.get('--box'),
                 ram=self.command_args.get('--box-memory'),
+                smp=self.command_args.get('--box-smp-cpus'),
                 arch=self._get_box_arch(),
                 machine=self.command_args.get('--machine'),
                 cpu=self.command_args.get('--cpu') or 'host',

--- a/test/unit/tasks/system_boxbuild_test.py
+++ b/test/unit/tasks/system_boxbuild_test.py
@@ -12,7 +12,7 @@ class TestSystemBoxbuildTask:
             sys.argv[0],
             '--profile', 'foo', '--type', 'oem',
             'system', 'boxbuild',
-            '--box', 'suse', '--box-memory', '4', '--',
+            '--box', 'suse', '--box-memory', '4', '--box-smp-cpus', '4', '--',
             '--description', '../data/description',
             '--target-dir', '../data/target_dir'
         ]
@@ -67,7 +67,7 @@ class TestSystemBoxbuildTask:
         mock_BoxBuild.return_value = box_build
         self.task.process()
         mock_BoxBuild.assert_called_once_with(
-            boxname='suse', ram=None, arch=None,
+            boxname='suse', ram=None, smp=None, arch=None,
             machine=None, cpu='host', sharing_backend='9p'
         )
         box_build.run.assert_called_once_with(
@@ -87,7 +87,7 @@ class TestSystemBoxbuildTask:
         mock_BoxBuild.return_value = box_build
         self.task.process()
         mock_BoxBuild.assert_called_once_with(
-            boxname='suse', ram=None, arch='x86_64',
+            boxname='suse', ram=None, smp=None, arch='x86_64',
             machine=None, cpu='host', sharing_backend='9p'
         )
 
@@ -101,7 +101,7 @@ class TestSystemBoxbuildTask:
         mock_BoxBuild.return_value = box_build
         self.task.process()
         mock_BoxBuild.assert_called_once_with(
-            boxname='suse', ram=None, arch='aarch64',
+            boxname='suse', ram=None, smp=None, arch='aarch64',
             machine=None, cpu='host', sharing_backend='9p'
         )
 
@@ -115,7 +115,7 @@ class TestSystemBoxbuildTask:
         mock_BoxBuild.return_value = box_build
         self.task.process()
         mock_BoxBuild.assert_called_once_with(
-            boxname='suse', ram=None, arch=None,
+            boxname='suse', ram=None, smp=None, arch=None,
             machine=None, cpu='host', sharing_backend='9p'
         )
         self.task.command_args['--9p-sharing'] = False
@@ -123,6 +123,6 @@ class TestSystemBoxbuildTask:
         mock_BoxBuild.reset_mock()
         self.task.process()
         mock_BoxBuild.assert_called_once_with(
-            boxname='suse', ram=None, arch=None,
+            boxname='suse', ram=None, smp=None, arch=None,
             machine=None, cpu='host', sharing_backend='virtiofs'
         )


### PR DESCRIPTION
Allow to configure the number of CPUs to use in the
SMP setup. By default 4 CPUs are used but this might
not be a good value especially in nested VM environment
This Fixes #24