### PR TITLE
Fixed creation of the build command passed to kiwi

### DIFF
--- a/kiwi_boxed_plugin/tasks/system_boxbuild.py
+++ b/kiwi_boxed_plugin/tasks/system_boxbuild.py
@@ -173,6 +173,7 @@ class SystemBoxbuildTask(CliTask):
             )
 
     def _validate_kiwi_build_command(self):
+        # construct build command from given command line
         kiwi_build_command = [
             'system', 'build'
         ]
@@ -181,15 +182,30 @@ class SystemBoxbuildTask(CliTask):
         )
         if '--' in kiwi_build_command:
             kiwi_build_command.remove('--')
+        # validate build command through docopt from the original
+        # kiwi.tasks.system_build docopt information
         log.info(
             'Validating kiwi_build_command_args:{0}    {1}'.format(
                 os.linesep, kiwi_build_command
             )
         )
-        docopt(
+        validated_build_command = docopt(
             doc=kiwi.tasks.system_build.__doc__,
             argv=kiwi_build_command
         )
+        # rebuild kiwi build command from validated docopt parser result
+        kiwi_build_command = [
+            'system', 'build'
+        ]
+        for option, value in validated_build_command.items():
+            if option.startswith('-') and value:
+                if isinstance(value, bool):
+                    kiwi_build_command.append(option)
+                elif isinstance(value, str):
+                    kiwi_build_command.extend([option, value])
+                elif isinstance(value, list):
+                    for element in value:
+                        kiwi_build_command.extend([option, element])
         final_kiwi_build_command = []
         if self.global_args.get('--type'):
             final_kiwi_build_command.append('--type')

--- a/test/unit/tasks/system_boxbuild_test.py
+++ b/test/unit/tasks/system_boxbuild_test.py
@@ -33,7 +33,9 @@ class TestSystemBoxbuildTask:
         self.task.command_args['--machine'] = None
         self.task.command_args['<kiwi_build_command_args>'] = [
             '--', '--description', 'foo',
-            '--target-dir', 'xxx'
+            '--target-dir', 'xxx',
+            '--add-package=a', '--add-package', 'b',
+            '--allow-existing-root'
         ]
 
     @patch('kiwi_boxed_plugin.tasks.system_boxbuild.Help')
@@ -73,7 +75,9 @@ class TestSystemBoxbuildTask:
         box_build.run.assert_called_once_with(
             [
                 '--type', 'oem', '--profile', 'foo', 'system', 'build',
-                '--description', 'foo', '--target-dir', 'xxx'
+                '--description', 'foo', '--target-dir', 'xxx',
+                '--allow-existing-root',
+                '--add-package', 'a', '--add-package', 'b'
             ], True, True, False, None, None
         )
 


### PR DESCRIPTION
The provided data in 'kiwi_build_command_args' from the
doc string of the kiwi boxbuild command is passed on as argument
to the kiwi build command inside of the box.

However the argument list is not fully compatible because for
the boxbuild command 'kiwi_build_command_args' is the argument
to the '--' option whereas for the build command any element
of what was provided in 'kiwi_build_command_args' is an option + value
for the build command.

Therefore it was possible to say "-- --description=foo" which
ends up as '--description=foo' to be passed as one option without
value to the build command which of course does not exist.

To fix it, this pull request makes sure that the information given
in the 'kiwi_build_command_args' is parsed using docopt against
the kiwi.tasks.system_build doc string and the result
of that parsing operation is used to construct the kiwi build
command.

This Fixes #33