### PR TITLE
Use progressbar python module

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -18,4 +18,4 @@ cerberus
 kiwi
 
 # download with progress info
-wget
+progressbar2

--- a/kiwi_boxed_plugin/box_download.py
+++ b/kiwi_boxed_plugin/box_download.py
@@ -16,12 +16,11 @@
 # along with kiwi-boxed-build.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
-import wget
-import contextlib
 import platform
 import logging
 from collections import namedtuple
 from kiwi_boxed_plugin.utils.dir_files import DirFiles
+from kiwi_boxed_plugin.utils.fetch_files import FetchFiles
 from kiwi.command import Command
 from kiwi.utils.checksum import Checksum
 from kiwi.solver.repository import SolverRepository
@@ -68,6 +67,7 @@ class BoxDownload:
 
         :param bool update_check: check for box updates True|False
         """
+        fetcher = FetchFiles()
         download = update_check
         repo_source = self.box_config.get_box_source()
         if repo_source:
@@ -114,11 +114,9 @@ class BoxDownload:
                     box_file_link = os.sep.join(
                         [repo._get_mime_typed_uri(), box_file]
                     )
-                    with BoxDownload._cd(os.path.dirname(local_box_file_tmp)):
-                        wget.download(
-                            url=box_file_link, out=local_box_file_tmp
-                        )
-                    print()
+                    fetcher.wget(
+                        url=box_file_link, filename=local_box_file_tmp
+                    )
 
             if download:
                 self.box_stage.commit()
@@ -171,12 +169,3 @@ class BoxDownload:
             ]
         )
         return os.sep.join([self.box_dir, f'initrd.{self.arch}'])
-
-    @contextlib.contextmanager
-    def _cd(path):
-        CWD = os.getcwd()
-        os.chdir(path)
-        try:
-            yield
-        finally:
-            os.chdir(CWD)

--- a/kiwi_boxed_plugin/utils/fetch_files.py
+++ b/kiwi_boxed_plugin/utils/fetch_files.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2021 SUSE Software Solutions Germany GmbH.  All rights reserved.
+#
+# This file is part of kiwi-boxed-build.
+#
+# kiwi-boxed-build is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi-boxed-build is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi-boxed-build.  If not, see <http://www.gnu.org/licenses/>
+#
+import requests
+import progressbar
+import requests.packages.urllib3
+
+
+class FetchFiles:
+    """
+    **Fetch File Manager**
+
+    Fetches file(s) from a given URL to the local system
+    """
+    def __init__(self) -> None:
+        requests.packages.urllib3.disable_warnings()
+
+    def wget(self, url: str, filename: str, chunk_size: int = 4096) -> None:
+        """
+        Download content of given url to filename
+
+        :param str url: URI
+        :param str filename: local file path name
+        """
+        response = requests.request(
+            'GET', url, stream=True, data=None, headers=None
+        )
+        widgets = [
+            'Loading: ', progressbar.Percentage(), ' ',
+            progressbar.Bar(marker='#', left='[', right=']'), ' ',
+            progressbar.ETA(), ' ',
+            progressbar.FileTransferSpeed()
+        ]
+        progress = progressbar.ProgressBar(
+            maxval=int(response.headers.get('Content-Length')),
+            widgets=widgets
+        ).start()
+        processed = 0
+        with open(filename, 'wb') as data:
+            for chunk in response.iter_content(chunk_size=chunk_size):
+                if chunk:
+                    data.write(chunk)
+                    data.flush()
+                    processed += len(chunk)
+                    progress.update(processed)
+        progress.finish()

--- a/package/python-kiwi_boxed_plugin-spec-template
+++ b/package/python-kiwi_boxed_plugin-spec-template
@@ -73,7 +73,7 @@ Requires:       python%{python3_pkgversion}-docopt
 Requires:       python%{python3_pkgversion}-kiwi >= 9.21.21
 Requires:       python%{python3_pkgversion}-requests
 Requires:       python%{python3_pkgversion}-setuptools
-Requires:       python%{python3_pkgversion}-wget
+Requires:       python%{python3_pkgversion}-progressbar2
 %if 0%{?ubuntu} || 0%{?debian}
 Requires:       python%{python3_pkgversion}-yaml
 %else

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ config = {
         'requests',
         'PyYAML',
         'cerberus',
-        'wget'
+        'progressbar2'
     ],
     'packages': ['kiwi_boxed_plugin'],
     'entry_points': {

--- a/test/unit/box_download_test.py
+++ b/test/unit/box_download_test.py
@@ -37,11 +37,13 @@ class TestBoxDownload:
     @patch('kiwi_boxed_plugin.box_download.Checksum')
     @patch('os.path.exists')
     @patch('os.chdir')
-    @patch('wget.download')
+    @patch('kiwi_boxed_plugin.box_download.FetchFiles')
     def test_fetch_checksum_did_not_match(
-        self, mock_wget_download, mock_os_chdir, mock_os_path_exist,
+        self, mock_FetchFiles, mock_os_chdir, mock_os_path_exist,
         mock_Checksum, mock_SolverRepository, mock_Uri, mock_Command_run
     ):
+        fetcher = Mock()
+        mock_FetchFiles.return_value = fetcher
         checksum = Mock()
         checksum.matches.return_value = False
         checksum.sha256.return_value = 'sum'
@@ -81,14 +83,14 @@ class TestBoxDownload:
                 'SUSE-Box.x86_64-1.42.1-System-BuildBox.report',
                 self.box_stage.register.return_value
             )
-            assert mock_wget_download.call_args_list == [
+            assert fetcher.wget.call_args_list == [
                 call(
                     url='uri:///SUSE-Box.x86_64-1.42.1-Kernel-BuildBox.tar.xz',
-                    out='register_file'
+                    filename='register_file'
                 ),
                 call(
                     url='uri:///SUSE-Box.x86_64-1.42.1-System-BuildBox.qcow2',
-                    out='register_file'
+                    filename='register_file'
                 )
             ]
             self.box_stage.commit.assert_called_once_with()

--- a/test/unit/utils/fetch_files_test.py
+++ b/test/unit/utils/fetch_files_test.py
@@ -1,0 +1,37 @@
+import io
+from mock import (
+    Mock, MagicMock, patch
+)
+
+from kiwi_boxed_plugin.utils.fetch_files import FetchFiles
+
+
+class TestFetchFiles:
+    def setup(self):
+        self.fetcher = FetchFiles()
+
+    @patch('kiwi_boxed_plugin.utils.fetch_files.requests')
+    @patch('kiwi_boxed_plugin.utils.fetch_files.progressbar')
+    def test_wget(self, mock_progressbar, mock_requests):
+        response = Mock()
+        response.headers.get.return_value = 4
+        response.iter_content.return_value = [b'data']
+        mock_requests.request.return_value = response
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            self.fetcher.wget('http://foo', 'bar')
+            mock_open.assert_called_once_with(
+                'bar', 'wb'
+            )
+            file_handle.write.assert_called_once_with(b'data')
+            mock_progressbar.ProgressBar.assert_called_once_with(
+                maxval=4,
+                widgets=[
+                    'Loading: ',
+                    mock_progressbar.Percentage.return_value, ' ',
+                    mock_progressbar.Bar(marker='#', left='[', right=']'), ' ',
+                    mock_progressbar.ETA.return_value, ' ',
+                    mock_progressbar.FileTransferSpeed.return_value
+                ]
+            )


### PR DESCRIPTION
As alternative to the no longer developed wget module
we are switching to the progressbar module. This requires
the code to fetch the data to be implemented through the
requests module to allow utilizing the progressbar as
it is designed. A nice after effect is that the progressbar
displayed is more sophisticated than the one before