### PR TITLE
Fixed initrd lookup

### DIFF
--- a/kiwi_boxed_plugin/box_download.py
+++ b/kiwi_boxed_plugin/box_download.py
@@ -170,7 +170,7 @@ class BoxDownload:
             [
                 'tar', '-C', self.box_dir,
                 '--transform', f's/.*/initrd.{self.arch}/',
-                '--wildcards', '-xf', tarfile, '*.initrd.xz'
+                '--wildcards', '-xf', tarfile, '*.initrd'
             ]
         )
         return os.sep.join([self.box_dir, f'initrd.{self.arch}'])

--- a/test/unit/box_download_test.py
+++ b/test/unit/box_download_test.py
@@ -114,7 +114,7 @@ class TestBoxDownload:
                         '--wildcards', '-xf',
                         'HOME/.kiwi_boxes/suse/'
                         'SUSE-Box.x86_64-1.42.1-Kernel-BuildBox.tar.xz',
-                        '*.initrd.xz'
+                        '*.initrd'
                     ]
                 )
             ]


### PR DESCRIPTION
Due to a change in kiwi with regards to the compression
algorithm used for initrd's in the distribution, the lookup
of the initrd file in boxbuild broke. kiwi uses by default
--xz but this is no longer correct for all distros.
Thus kiwi does not longer force xz for compressing initrds
created by dracut. For details see: OSInside/kiwi#1987
This commit fixes the box plugin to work with that kiwi
change.