### PR TITLE
Added support for boxroot overlay files

### DIFF
--- a/boxes/images.sh
+++ b/boxes/images.sh
@@ -109,6 +109,15 @@ function mount_shared_path {
     fi
 }
 
+function import_box_overlay_files {
+    # """
+    # Import optional boxroot overlay tree into box system
+    # """
+    if [ -d /description/boxroot ];then
+        rsync -zav /description/boxroot/ /
+    fi
+}
+
 function import_box_variables {
     # """
     # Box variables are those which uses the =_*_ notation
@@ -171,5 +180,7 @@ if [ -n "${kiwi_version}" ]; then
         exit 1
     fi
 fi
+
+import_box_overlay_files
 
 run_build


### PR DESCRIPTION
Check for a directory boxroot and rsync its contents
into the box system prior building the image.
This Fixes #48