### PR TITLE
Allow to configure hardware acceleration

### DIFF
--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -32,7 +32,7 @@ types-PyYAML
 types-mock
 
 # for building documentation
-sphinx
+sphinx>=5.0.0
 sphinx_rtd_theme
 
 # for release

--- a/doc/source/commands/system_boxbuild.rst
+++ b/doc/source/commands/system_boxbuild.rst
@@ -17,6 +17,7 @@ SYNOPSIS
        [--shared-path=<path>]
        [--no-update-check]
        [--no-snapshot]
+       [--no-accel]
        [--9p-sharing | --virtiofs-sharing | --sshfs-sharing]
        [--ssh-key=<name>]
        [--x86_64 | --aarch64]
@@ -96,6 +97,12 @@ OPTIONS
   used with care. On update of the box all data stored
   will be wiped. To prevent this combine the option with
   the --no-update-check option.
+
+--no-accel
+
+  Run box without hardware acceleration. By default KVM
+  acceleration is activated
+
 
 --9p-sharing|--virtiofs-sharing|--sshfs-sharing
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -70,13 +70,6 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
-extlinks = {
-    'issue': ('https://github.com/OSInside/kiwi-boxed-plugin/issues/%s', '#'),
-    'pr': ('https://github.com/OSInside/kiwi-boxed-plugin/pull/%s', 'PR #'),
-    'ghkiwi': ('https://github.com/OSInside/kiwi-boxed-plugin/blob/master/%s', '')
-}
-
-
 autosummary_generate = True
 
 # -- Options for HTML output ----------------------------------------------

--- a/kiwi_boxed_plugin/box_build.py
+++ b/kiwi_boxed_plugin/box_build.py
@@ -58,7 +58,8 @@ class BoxBuild:
     def __init__(
         self, boxname: str, ram: str = '', smp: str = '',
         arch: str = '', machine: str = '', cpu: str = 'host',
-        sharing_backend: str = '9p', ssh_key: str = 'id_rsa'
+        sharing_backend: str = '9p', ssh_key: str = 'id_rsa',
+        accel: bool = True
     ) -> None:
         self.ram = ram
         self.smp = smp
@@ -69,6 +70,7 @@ class BoxBuild:
         self.sharing_backend = sharing_backend
         self.ssh_key = ssh_key
         self.kiwi_exit: Optional[int] = None
+        self.accel = accel
 
     def run(
         self, kiwi_build_command: List[str], update_check: bool = True,
@@ -143,14 +145,15 @@ class BoxBuild:
         vm_append.append(
             'sharing_backend=_{0}_'.format(self.sharing_backend)
         )
-        vm_machine = [
-            '-machine'
-        ]
+        vm_machine = []
         if self.machine:
+            vm_machine.append('-machine')
             vm_machine.append(self.machine)
-        if self.arch == 'x86_64':
-            # KVM is only present for Intel and AMD
+
+        if self.accel:
+            vm_machine.append('-accel')
             vm_machine.append('accel=kvm')
+
         vm_machine.append('-cpu')
         vm_machine.append(self.cpu)
         qemu_binary = self._find_qemu_call_binary()

--- a/kiwi_boxed_plugin/tasks/system_boxbuild.py
+++ b/kiwi_boxed_plugin/tasks/system_boxbuild.py
@@ -25,6 +25,7 @@ usage: kiwi-ng system boxbuild -h | --help
            [--shared-path=<path>]
            [--no-update-check]
            [--no-snapshot]
+           [--no-accel]
            [--9p-sharing | --virtiofs-sharing | --sshfs-sharing]
            [--ssh-key=<name>]
            [--x86_64 | --aarch64]
@@ -71,6 +72,10 @@ options:
         used with care. On update of the box all data stored
         will be wiped. To prevent this combine the option with
         the --no-update-check option.
+
+    --no-accel
+        Run box without hardware acceleration. By default KVM
+        acceleration is activated
 
     --9p-sharing|--virtiofs-sharing|--sshfs-sharing
         Select sharing backend to use for sharing data between the
@@ -168,7 +173,8 @@ class SystemBoxbuildTask(CliTask):
                 machine=self.command_args.get('--machine'),
                 cpu=self.command_args.get('--cpu') or 'host',
                 sharing_backend=self._get_sharing_backend(),
-                ssh_key=self.command_args.get('--ssh-key') or 'id_rsa'
+                ssh_key=self.command_args.get('--ssh-key') or 'id_rsa',
+                accel=not bool(self.command_args.get('--no-accel'))
             )
             box_build.run(
                 self._validate_kiwi_build_command(),

--- a/test/unit/box_build_test.py
+++ b/test/unit/box_build_test.py
@@ -81,7 +81,7 @@ class TestBoxBuild:
         mock_os_system.assert_called_once_with(
             'qemu-system-x86_64 '
             '-m 4096 '
-            '-machine accel=kvm '
+            '-accel accel=kvm '
             '-cpu host '
             '-nographic '
             '-nodefaults '
@@ -133,6 +133,7 @@ class TestBoxBuild:
             'qemu-system-aarch64 '
             '-m 4096 '
             '-machine virt '
+            '-accel accel=kvm '
             '-cpu cortex-a57 '
             '-nographic '
             '-nodefaults '
@@ -255,7 +256,7 @@ class TestBoxBuild:
         mock_os_system.assert_called_once_with(
             'qemu-system-x86_64 '
             '-m 4096 '
-            '-machine accel=kvm '
+            '-accel accel=kvm '
             '-cpu host '
             '-nographic '
             '-nodefaults '
@@ -363,7 +364,7 @@ class TestBoxBuild:
         mock_os_system.assert_called_once_with(
             'qemu-system-x86_64 '
             '-m 4096 '
-            '-machine accel=kvm '
+            '-accel accel=kvm '
             '-cpu host '
             '-nographic '
             '-nodefaults '

--- a/test/unit/tasks/system_boxbuild_test.py
+++ b/test/unit/tasks/system_boxbuild_test.py
@@ -75,7 +75,7 @@ class TestSystemBoxbuildTask:
         mock_BoxBuild.assert_called_once_with(
             boxname='suse', ram=None, smp=None, arch='',
             machine=None, cpu='host', sharing_backend='9p',
-            ssh_key='id_rsa'
+            ssh_key='id_rsa', accel=True
         )
         box_build.run.assert_called_once_with(
             [
@@ -98,7 +98,7 @@ class TestSystemBoxbuildTask:
         mock_BoxBuild.assert_called_once_with(
             boxname='suse', ram=None, smp=None, arch='x86_64',
             machine=None, cpu='host', sharing_backend='9p',
-            ssh_key='id_rsa'
+            ssh_key='id_rsa', accel=True
         )
 
     @patch('kiwi_boxed_plugin.tasks.system_boxbuild.BoxBuild')
@@ -113,7 +113,7 @@ class TestSystemBoxbuildTask:
         mock_BoxBuild.assert_called_once_with(
             boxname='suse', ram=None, smp=None, arch='aarch64',
             machine=None, cpu='host', sharing_backend='9p',
-            ssh_key='id_rsa'
+            ssh_key='id_rsa', accel=True
         )
 
     @patch('kiwi_boxed_plugin.tasks.system_boxbuild.BoxBuild')
@@ -128,7 +128,7 @@ class TestSystemBoxbuildTask:
         mock_BoxBuild.assert_called_once_with(
             boxname='suse', ram=None, smp=None, arch='',
             machine=None, cpu='host', sharing_backend='9p',
-            ssh_key='id_rsa'
+            ssh_key='id_rsa', accel=True
         )
         self.task.command_args['--9p-sharing'] = False
         self.task.command_args['--virtiofs-sharing'] = True
@@ -137,7 +137,7 @@ class TestSystemBoxbuildTask:
         mock_BoxBuild.assert_called_once_with(
             boxname='suse', ram=None, smp=None, arch='',
             machine=None, cpu='host', sharing_backend='virtiofs',
-            ssh_key='id_rsa'
+            ssh_key='id_rsa', accel=True
         )
         self.task.command_args['--9p-sharing'] = False
         self.task.command_args['--virtiofs-sharing'] = False
@@ -147,5 +147,5 @@ class TestSystemBoxbuildTask:
         mock_BoxBuild.assert_called_once_with(
             boxname='suse', ram=None, smp=None, arch='',
             machine=None, cpu='host', sharing_backend='sshfs',
-            ssh_key='id_rsa'
+            ssh_key='id_rsa', accel=True
         )


### PR DESCRIPTION
By default KVM acceleration is switched on but can be
disabled with the new --no-accel option. Also the check
for KVM on x86 only has been deleted