### PR TITLE
Make sure --debug switch has an effect

### DIFF
--- a/kiwi_boxed_plugin/tasks/system_boxbuild.py
+++ b/kiwi_boxed_plugin/tasks/system_boxbuild.py
@@ -220,6 +220,8 @@ class SystemBoxbuildTask(CliTask):
                     for element in value:
                         kiwi_build_command.extend([option, element])
         final_kiwi_build_command = []
+        if self.global_args.get('--debug'):
+            final_kiwi_build_command.append('--debug')
         if self.global_args.get('--type'):
             final_kiwi_build_command.append('--type')
             final_kiwi_build_command.append(self.global_args.get('--type'))

--- a/test/unit/box_build_test.py
+++ b/test/unit/box_build_test.py
@@ -70,7 +70,7 @@ class TestBoxBuild:
         mock_path_which.return_value = 'qemu-system-x86_64'
         self.build.run(
             [
-                '--type', 'oem', 'system', 'build',
+                '--debug', '--type', 'oem', 'system', 'build',
                 '--description', 'desc', '--target-dir', 'target'
             ],
             keep_open=True,
@@ -87,7 +87,7 @@ class TestBoxBuild:
             '-nodefaults '
             '-snapshot '
             '-kernel kernel '
-            '-append "append kiwi=\\"--type oem system build\\"'
+            '-append "append kiwi=\\"--debug --type oem system build\\"'
             ' kiwi-no-halt kiwi_version=_9.22.1_'
             ' custom_mount=_/var/tmp/repos_'
             ' sharing_backend=_9p_" '

--- a/test/unit/tasks/system_boxbuild_test.py
+++ b/test/unit/tasks/system_boxbuild_test.py
@@ -10,7 +10,7 @@ class TestSystemBoxbuildTask:
     def setup(self):
         sys.argv = [
             sys.argv[0],
-            '--profile', 'foo', '--type', 'oem',
+            '--debug', '--profile', 'foo', '--type', 'oem',
             'system', 'boxbuild',
             '--box', 'suse', '--box-memory', '4', '--box-smp-cpus', '4', '--',
             '--description', '../data/description',
@@ -79,7 +79,8 @@ class TestSystemBoxbuildTask:
         )
         box_build.run.assert_called_once_with(
             [
-                '--type', 'oem', '--profile', 'foo', 'system', 'build',
+                '--debug', '--type', 'oem', '--profile', 'foo',
+                'system', 'build',
                 '--description', 'foo', '--target-dir', 'xxx',
                 '--allow-existing-root',
                 '--add-package', 'a', '--add-package', 'b'


### PR DESCRIPTION
This commit makes sure that the global --debug switch is used when kiwi is called inside of the box VM