### PR TITLE
Add the ability to set the SSH forwarding port on the host

### DIFF
--- a/kiwi_boxed_plugin/defaults.py
+++ b/kiwi_boxed_plugin/defaults.py
@@ -24,7 +24,6 @@ import subprocess
 from kiwi_boxed_plugin.exceptions import KiwiBoxPluginVirtioFsError
 
 VIRTIOFSD_PROCESS_LIST = []
-BOX_SSH_PORT_FORWARDED_TO_HOST = 10022
 HOST_SSH_PORT_FORWARDED_TO_BOX = 10000
 
 
@@ -34,6 +33,8 @@ class Defaults:
 
     Provides static methods for default values and state information
     """
+    box_ssh_port_forwarded_to_host = 10022
+
     @staticmethod
     def get_plugin_config_file() -> str:
         return resource_filename(
@@ -56,7 +57,7 @@ class Defaults:
     def get_qemu_network_setup() -> List[str]:
         return [
             '-netdev',
-            f'user,id=user0,hostfwd=tcp::{BOX_SSH_PORT_FORWARDED_TO_HOST}-:22',
+            f'user,id=user0,hostfwd=tcp::{Defaults.box_ssh_port_forwarded_to_host}-:22',
             '-device', 'virtio-net-pci,netdev=user0'
         ]
 

--- a/kiwi_boxed_plugin/exceptions.py
+++ b/kiwi_boxed_plugin/exceptions.py
@@ -47,3 +47,9 @@ class KiwiBoxPluginQEMUBinaryNotFound(KiwiError):
     Exception raised if no QEMU binary for the desired architecture
     could be found
     """
+
+
+class KiwiBoxPluginSSHPortInvalid(KiwiError):
+    """
+    Exception raised if an invalid SSH port is passed as an argument
+    """

--- a/kiwi_boxed_plugin/tasks/system_boxbuild.py
+++ b/kiwi_boxed_plugin/tasks/system_boxbuild.py
@@ -28,6 +28,7 @@ usage: kiwi-ng system boxbuild -h | --help
            [--no-accel]
            [--9p-sharing | --virtiofs-sharing | --sshfs-sharing]
            [--ssh-key=<name>]
+           [--ssh-port=<port>]
            [--x86_64 | --aarch64]
            [--machine=<qemu_machine>]
            [--cpu=<qemu_cpu>]
@@ -85,6 +86,10 @@ options:
     --ssh-key=<name>
         Name of ssh key to authorize for connection.
         By default 'id_rsa' is used.
+
+    --ssh-port=<port>
+        Port number to use to forward the guest's SSH port to the host
+        By default '10022' is used.
 
     --x86_64|--aarch64
         Select box for the given architecture. If no architecture
@@ -174,6 +179,7 @@ class SystemBoxbuildTask(CliTask):
                 cpu=self.command_args.get('--cpu') or 'host',
                 sharing_backend=self._get_sharing_backend(),
                 ssh_key=self.command_args.get('--ssh-key') or 'id_rsa',
+                ssh_port=self.command_args.get('--ssh-port') or '',
                 accel=not bool(self.command_args.get('--no-accel'))
             )
             box_build.run(


### PR DESCRIPTION
It is not currently possible to run multiple Kiwi instances using box build at the same time as they will all share the same SSH port. This patch adds the command line argument `--ssh-port`, which allows the user to specify an SSH port to use for the connection to the guest. The argument takes a single positive integer value.