### PR TITLE
kiwi_boxed_plugin: utils: fetch_files: improve progressbar import

### DIFF
--- a/kiwi_boxed_plugin/utils/fetch_files.py
+++ b/kiwi_boxed_plugin/utils/fetch_files.py
@@ -16,7 +16,10 @@
 # along with kiwi-boxed-build.  If not, see <http://www.gnu.org/licenses/>
 #
 import requests
-import progressbar
+try:
+    import progressbar2 as progressbar
+except ImportError:
+    import progressbar
 import requests.packages.urllib3
 
 


### PR DESCRIPTION
The progressbar2 module is installed on Debian-based systems as "progressbar2", and can be imported as such, but if progressbar2 has been installed from pip the module is called "progressbar". Adjust the import of this module to first try importing "progressbar2", and if it fails, fall back to "progressbar". This stops the tool from trying to import the old progressbar module rather than the correct progressbar2 module.

See the file lists in the `python3-progressbar2` and `python3-progressbar` packages in Ubuntu for reference:
 - https://packages.ubuntu.com/mantic/all/python3-progressbar2/filelist
 - https://packages.ubuntu.com/mantic/all/python3-progressbar/filelist