### PR TITLE
Add support for --box-console

### DIFF
--- a/doc/source/commands/system_boxbuild.rst
+++ b/doc/source/commands/system_boxbuild.rst
@@ -11,6 +11,7 @@ SYNOPSIS
    kiwi-ng system boxbuild -h | --help
    kiwi-ng system boxbuild --box=<name>
        [--box-memory=<vmgb>]
+       [--box-console=<ttyname>]
        [--box-smp-cpus=<number>]
        [--box-debug]
        [--kiwi-version=<version>]
@@ -74,6 +75,11 @@ OPTIONS
 
   Number of GBs to reserve as main memory for the virtual
   machine. By default 8GB will be used.
+
+--box-console=<ttyname>
+
+  Name of console in the kernel settings for the virtual
+  machine. By default set to hvc0.
 
 --box-smp-cpus=<number>
 

--- a/kiwi_boxed_plugin/box_build.py
+++ b/kiwi_boxed_plugin/box_build.py
@@ -50,6 +50,7 @@ class BoxBuild:
 
     :param str boxname: name of the box from kiwi_boxed_plugin.yml
     :param str ram: amount of main memory to use for the box
+    :param str console: console name for the box kernel
     :param str smp: number of CPUs to use in the SMP setup for the box
     :param str arch: arch name for box
     :param str machine: machine emulaton type for the box
@@ -58,12 +59,13 @@ class BoxBuild:
     :param str ssh_port: host port number to use to forward the guest's SSH port
     """
     def __init__(
-        self, boxname: str, ram: str = '', smp: str = '',
+        self, boxname: str, ram: str = '', console: str = '', smp: str = '',
         arch: str = '', machine: str = '', cpu: str = 'host',
         sharing_backend: str = '9p', ssh_key: str = 'id_rsa',
         ssh_port: str = '', accel: bool = True
     ) -> None:
         self.ram = ram
+        self.console = console
         self.smp = smp
         self.cpu = cpu
         self.machine = machine
@@ -111,6 +113,10 @@ class BoxBuild:
             vm_setup.append,
             'kiwi=\\"{0}\\"'.format(' '.join(self.kiwi_build_command))
         ]
+        if self.console:
+            vm_append[0] = vm_append[0].replace(
+                f'console={vm_setup.console}', f'console={self.console}'
+            )
         if keep_open:
             vm_append.append('kiwi-no-halt')
         if kiwi_version:

--- a/kiwi_boxed_plugin/box_download.py
+++ b/kiwi_boxed_plugin/box_download.py
@@ -36,6 +36,7 @@ vm_setup_type = NamedTuple(
         ('kernel', str),
         ('initrd', str),
         ('append', str),
+        ('console', str),
         ('ram', str),
         ('smp', str)
     ]
@@ -147,6 +148,7 @@ class BoxDownload:
                 self.box_config.get_box_console(),
                 self.box_config.get_box_kernel_cmdline()
             ),
+            console=self.box_config.get_box_console(),
             ram=self.box_config.get_box_memory_mbytes(),
             smp=self.box_config.get_box_processors()
         )

--- a/kiwi_boxed_plugin/tasks/system_boxbuild.py
+++ b/kiwi_boxed_plugin/tasks/system_boxbuild.py
@@ -19,6 +19,7 @@
 usage: kiwi-ng system boxbuild -h | --help
        kiwi-ng system boxbuild --box=<name>
            [--box-memory=<vmgb>]
+           [--box-console=<ttyname>]
            [--box-smp-cpus=<number>]
            [--box-debug]
            [--kiwi-version=<version>]
@@ -53,6 +54,10 @@ options:
     --box-memory=<vmgb>
         Number of GBs to reserve as main memory for the virtual
         machine. By default 8GB will be used.
+
+    --box-console=<ttyname>
+        Name of console in the kernel settings for the virtual
+        machine. By default set to hvc0.
 
     --box-smp-cpus=<number>
         Number of CPUs to use in the SMP setup. By default
@@ -173,6 +178,7 @@ class SystemBoxbuildTask(CliTask):
             box_build = BoxBuild(
                 boxname=self.command_args.get('--box'),
                 ram=self.command_args.get('--box-memory'),
+                console=self.command_args.get('--box-console'),
                 smp=self.command_args.get('--box-smp-cpus'),
                 arch=self._get_box_arch(),
                 machine=self.command_args.get('--machine'),

--- a/test/unit/box_build_test.py
+++ b/test/unit/box_build_test.py
@@ -24,9 +24,10 @@ class TestBoxBuild:
         self.box = Mock()
         self.vm_setup = Mock()
         self.vm_setup.kernel = 'kernel'
-        self.vm_setup.append = 'append'
+        self.vm_setup.append = 'console=hvc0'
         self.vm_setup.system = 'system'
         self.vm_setup.initrd = 'initrd'
+        self.vm_setup.console = 'hvc0'
         self.vm_setup.ram = 4096
         self.vm_setup.smp = 4
         self.box.fetch.return_value = self.vm_setup
@@ -36,7 +37,8 @@ class TestBoxBuild:
         )
         self.build_arm = BoxBuild(
             boxname='universal', arch='aarch64',
-            machine='virt', cpu='cortex-a57'
+            machine='virt', cpu='cortex-a57',
+            console='ttyAMA0'
         )
 
     @patch('kiwi_boxed_plugin.box_build.BoxDownload')
@@ -106,7 +108,7 @@ class TestBoxBuild:
             '-nodefaults '
             '-snapshot '
             '-kernel kernel '
-            '-append "append kiwi=\\"--debug --type oem system build\\"'
+            '-append "console=hvc0 kiwi=\\"--debug --type oem system build\\"'
             ' kiwi-no-halt kiwi_version=_9.22.1_'
             ' custom_mount=_/var/tmp/repos_'
             ' sharing_backend=_9p_" '
@@ -158,7 +160,7 @@ class TestBoxBuild:
             '-nodefaults '
             '-snapshot '
             '-kernel kernel '
-            '-append "append kiwi=\\"--type oem system build\\"'
+            '-append "console=ttyAMA0 kiwi=\\"--type oem system build\\"'
             ' kiwi-no-halt kiwi_version=_9.22.1_'
             ' custom_mount=_/var/tmp/repos_'
             ' sharing_backend=_9p_" '
@@ -281,7 +283,7 @@ class TestBoxBuild:
             '-nodefaults '
             '-snapshot '
             '-kernel kernel '
-            '-append "append kiwi=\\"--type oem system build\\"'
+            '-append "console=hvc0 kiwi=\\"--type oem system build\\"'
             ' kiwi-no-halt kiwi_version=_9.22.1_'
             ' custom_mount=_var/tmp/repos_'
             ' sharing_backend=_virtiofs_" '
@@ -390,7 +392,7 @@ class TestBoxBuild:
             '-nodefaults '
             '-snapshot '
             '-kernel kernel '
-            '-append "append kiwi=\\"--type oem system build\\"'
+            '-append "console=hvc0 kiwi=\\"--type oem system build\\"'
             ' kiwi-no-halt kiwi_version=_9.22.1_'
             ' custom_mount=_var/tmp/repos_'
             ' ssh_key=_key_value_'

--- a/test/unit/box_download_test.py
+++ b/test/unit/box_download_test.py
@@ -29,6 +29,7 @@ class TestBoxDownload:
             kernel='HOME/.kiwi_boxes/suse/kernel.x86_64',
             initrd='HOME/.kiwi_boxes/suse/initrd.x86_64',
             append='console=hvc0 root=/dev/vda1 rd.plymouth=0',
+            console='hvc0',
             ram=8096,
             smp=4
         )

--- a/test/unit/tasks/system_boxbuild_test.py
+++ b/test/unit/tasks/system_boxbuild_test.py
@@ -12,7 +12,11 @@ class TestSystemBoxbuildTask:
             sys.argv[0],
             '--debug', '--profile', 'foo', '--type', 'oem',
             'system', 'boxbuild',
-            '--box', 'suse', '--box-memory', '4', '--box-smp-cpus', '4', '--',
+            '--box', 'universal',
+            '--box-memory', '4',
+            '--box-console', 'ttyAMA0',
+            '--box-smp-cpus', '4',
+            '--',
             '--description', '../data/description',
             '--target-dir', '../data/target_dir'
         ]
@@ -69,12 +73,12 @@ class TestSystemBoxbuildTask:
     def test_process_system_boxbuild(self, mock_BoxBuild):
         self._init_command_args()
         self.task.command_args['boxbuild'] = True
-        self.task.command_args['--box'] = 'suse'
+        self.task.command_args['--box'] = 'universal'
         box_build = Mock()
         mock_BoxBuild.return_value = box_build
         self.task.process()
         mock_BoxBuild.assert_called_once_with(
-            boxname='suse', ram=None, smp=None, arch='',
+            boxname='universal', ram=None, console=None, smp=None, arch='',
             machine=None, cpu='host', sharing_backend='9p',
             ssh_key='id_rsa', ssh_port='22', accel=True
         )
@@ -92,13 +96,14 @@ class TestSystemBoxbuildTask:
     def test_process_system_boxbuild_for_x86_64(self, mock_BoxBuild):
         self._init_command_args()
         self.task.command_args['boxbuild'] = True
-        self.task.command_args['--box'] = 'suse'
+        self.task.command_args['--box'] = 'universal'
         self.task.command_args['--x86_64'] = True
         box_build = Mock()
         mock_BoxBuild.return_value = box_build
         self.task.process()
         mock_BoxBuild.assert_called_once_with(
-            boxname='suse', ram=None, smp=None, arch='x86_64',
+            boxname='universal',
+            ram=None, console=None, smp=None, arch='x86_64',
             machine=None, cpu='host', sharing_backend='9p',
             ssh_key='id_rsa', ssh_port='22', accel=True
         )
@@ -107,13 +112,14 @@ class TestSystemBoxbuildTask:
     def test_process_system_boxbuild_for_aarch64(self, mock_BoxBuild):
         self._init_command_args()
         self.task.command_args['boxbuild'] = True
-        self.task.command_args['--box'] = 'suse'
+        self.task.command_args['--box'] = 'universal'
         self.task.command_args['--aarch64'] = True
         box_build = Mock()
         mock_BoxBuild.return_value = box_build
         self.task.process()
         mock_BoxBuild.assert_called_once_with(
-            boxname='suse', ram=None, smp=None, arch='aarch64',
+            boxname='universal',
+            ram=None, console=None, smp=None, arch='aarch64',
             machine=None, cpu='host', sharing_backend='9p',
             ssh_key='id_rsa', ssh_port='22', accel=True
         )
@@ -122,13 +128,13 @@ class TestSystemBoxbuildTask:
     def test_process_system_boxbuild_with_sharing_backend(self, mock_BoxBuild):
         self._init_command_args()
         self.task.command_args['boxbuild'] = True
-        self.task.command_args['--box'] = 'suse'
+        self.task.command_args['--box'] = 'universal'
         self.task.command_args['--9p-sharing'] = True
         box_build = Mock()
         mock_BoxBuild.return_value = box_build
         self.task.process()
         mock_BoxBuild.assert_called_once_with(
-            boxname='suse', ram=None, smp=None, arch='',
+            boxname='universal', ram=None, console=None, smp=None, arch='',
             machine=None, cpu='host', sharing_backend='9p',
             ssh_key='id_rsa', ssh_port='22', accel=True
         )
@@ -137,7 +143,7 @@ class TestSystemBoxbuildTask:
         mock_BoxBuild.reset_mock()
         self.task.process()
         mock_BoxBuild.assert_called_once_with(
-            boxname='suse', ram=None, smp=None, arch='',
+            boxname='universal', ram=None, console=None, smp=None, arch='',
             machine=None, cpu='host', sharing_backend='virtiofs',
             ssh_key='id_rsa', ssh_port='22', accel=True
         )
@@ -147,7 +153,7 @@ class TestSystemBoxbuildTask:
         mock_BoxBuild.reset_mock()
         self.task.process()
         mock_BoxBuild.assert_called_once_with(
-            boxname='suse', ram=None, smp=None, arch='',
+            boxname='universal', ram=None, console=None, smp=None, arch='',
             machine=None, cpu='host', sharing_backend='sshfs',
             ssh_key='id_rsa', ssh_port='22', accel=True
         )


### PR DESCRIPTION
Allow to specify console name for the kernel,
by default set to hvc0