### PR TITLE
Fixed use of virtiofs sharing backend

### DIFF
--- a/kiwi_boxed_plugin/box_build.py
+++ b/kiwi_boxed_plugin/box_build.py
@@ -173,6 +173,7 @@ class BoxBuild:
 
         vm_machine.append('-cpu')
         vm_machine.append(self.cpu)
+        vm_memory = format(self.ram or vm_setup.ram)
         qemu_binary = self._find_qemu_call_binary()
         if not qemu_binary:
             raise KiwiBoxPluginQEMUBinaryNotFound(
@@ -180,7 +181,7 @@ class BoxBuild:
             )
         vm_run = [
             qemu_binary,
-            '-m', format(self.ram or vm_setup.ram)
+            '-m', vm_memory
         ] + vm_machine + [
         ] + Defaults.get_qemu_generic_setup() + [
             '-kernel', vm_setup.kernel,
@@ -199,7 +200,7 @@ class BoxBuild:
         if self.sharing_backend == 'virtiofs':
             vm_run += [
                 '-object', '{0},id=mem,size={1},mem-path={2},share=on'.format(
-                    'memory-backend-file', self.ram or vm_setup.ram, '/dev/shm'
+                    'memory-backend-file', vm_memory, '/dev/shm'
                 ),
                 '-numa', 'node,memdev=mem'
             ]

--- a/kiwi_boxed_plugin/config/kiwi_boxed_plugin.yml
+++ b/kiwi_boxed_plugin/config/kiwi_boxed_plugin.yml
@@ -1,7 +1,7 @@
 box:
   -
     name: tumbleweed
-    mem_mb: 8096
+    mem_mb: 8096M
     processors: 4
     console: hvc0
     arch:
@@ -45,7 +45,7 @@ box:
 
   -
     name: leap
-    mem_mb: 8096
+    mem_mb: 8096M
     processors: 4
     console: hvc0
     arch:
@@ -63,7 +63,7 @@ box:
 
   -
     name: fedora
-    mem_mb: 8096
+    mem_mb: 8096M
     processors: 4
     console: hvc0
     arch:
@@ -82,7 +82,7 @@ box:
 
   -
     name: ubuntu
-    mem_mb: 8096
+    mem_mb: 8096M
     processors: 4
     console: hvc0
     arch:
@@ -114,7 +114,7 @@ box:
 
   -
     name: universal
-    mem_mb: 8096
+    mem_mb: 8096M
     processors: 4
     console: hvc0
     arch:

--- a/kiwi_boxed_plugin/defaults.py
+++ b/kiwi_boxed_plugin/defaults.py
@@ -130,7 +130,7 @@ class Defaults:
     def get_qemu_shared_path_setup_virtiofs(
         index: int, path: str, mount_tag: str
     ) -> List[str]:
-        virtiofsd_lookup_paths = ['/usr/lib', '/usr/libexec']
+        virtiofsd_lookup_paths = ['/usr/lib/virtiofsd', '/usr/libexec']
         virtiofsd = Path.which(
             'virtiofsd', virtiofsd_lookup_paths
         )
@@ -143,9 +143,12 @@ class Defaults:
                 [
                     virtiofsd,
                     '--socket-path=/tmp/vhostqemu_{0}'.format(index),
-                    '-o', 'allow_root',
-                    '-o', 'source={0}'.format(os.path.abspath(path)),
-                    '-o', 'cache=always'
+                    '--shared-dir', os.path.abspath(path),
+                    '--sandbox', 'namespace',
+                    '--cache', 'always',
+                    '--allow-direct-io',
+                    '--posix-acl',
+                    '--xattr'
                 ], close_fds=True
             )
         except Exception as issue:

--- a/kiwi_boxed_plugin/plugin_config_schema.py
+++ b/kiwi_boxed_plugin/plugin_config_schema.py
@@ -11,7 +11,7 @@ schema = {
                     'empty': False
                 },
                 'mem_mb': {
-                    'type': 'number',
+                    'type': 'string',
                     'required': True,
                     'empty': False
                 },

--- a/package/python-kiwi_boxed_plugin-spec-template
+++ b/package/python-kiwi_boxed_plugin-spec-template
@@ -85,6 +85,8 @@ Requires:       python%{python3_pkgversion}-Cerberus
 Requires:       python%{python3_pkgversion}-cerberus
 %endif
 Requires:       qemu
+Recommends:     sshfs
+Recommends:     virtiofsd >= 1.10
 
 %description -n python%{python3_pkgversion}-kiwi_boxed_plugin
 The KIWI boxed plugin provides support for self contained building

--- a/test/data/kiwi_boxed_plugin.yml
+++ b/test/data/kiwi_boxed_plugin.yml
@@ -1,7 +1,7 @@
 box:
   -
     name: suse
-    mem_mb: 8096
+    mem_mb: 8096M
     processors: 4
     console: hvc0
     arch:
@@ -19,7 +19,7 @@ box:
 
   -
     name: universal
-    mem_mb: 8096
+    mem_mb: 8096M
     processors: 4
     console: hvc0
     arch:

--- a/test/unit/box_build_test.py
+++ b/test/unit/box_build_test.py
@@ -310,27 +310,36 @@ class TestBoxBuild:
                 [
                     '/usr/libexec/virtiofsd',
                     '--socket-path=/tmp/vhostqemu_0',
-                    '-o', 'allow_root',
-                    '-o', 'source=abspath/desc',
-                    '-o', 'cache=always'
+                    '--shared-dir', 'abspath/desc',
+                    '--sandbox', 'namespace',
+                    '--cache', 'always',
+                    '--allow-direct-io',
+                    '--posix-acl',
+                    '--xattr'
                 ], close_fds=True
             ),
             call(
                 [
                     '/usr/libexec/virtiofsd',
                     '--socket-path=/tmp/vhostqemu_1',
-                    '-o', 'allow_root',
-                    '-o', 'source=abspath/target',
-                    '-o', 'cache=always'
+                    '--shared-dir', 'abspath/target',
+                    '--sandbox', 'namespace',
+                    '--cache', 'always',
+                    '--allow-direct-io',
+                    '--posix-acl',
+                    '--xattr'
                 ], close_fds=True
             ),
             call(
                 [
                     '/usr/libexec/virtiofsd',
                     '--socket-path=/tmp/vhostqemu_2',
-                    '-o', 'allow_root',
-                    '-o', 'source=abspath/var/tmp/repos',
-                    '-o', 'cache=always'
+                    '--shared-dir', 'abspath/var/tmp/repos',
+                    '--sandbox', 'namespace',
+                    '--cache', 'always',
+                    '--allow-direct-io',
+                    '--posix-acl',
+                    '--xattr'
                 ], close_fds=True
             )
         ]

--- a/test/unit/box_config_test.py
+++ b/test/unit/box_config_test.py
@@ -56,7 +56,7 @@ class TestBoxConfig:
         assert self.box_config.get_box_arch() == 'x86_64'
 
     def test_get_box_memory_mbytes(self):
-        assert self.box_config.get_box_memory_mbytes() == 8096
+        assert self.box_config.get_box_memory_mbytes() == '8096M'
 
     def test_get_box_console(self):
         assert self.box_config.get_box_console() == 'hvc0'

--- a/test/unit/box_download_test.py
+++ b/test/unit/box_download_test.py
@@ -30,7 +30,7 @@ class TestBoxDownload:
             initrd='HOME/.kiwi_boxes/suse/initrd.x86_64',
             append='console=hvc0 root=/dev/vda1 rd.plymouth=0',
             console='hvc0',
-            ram=8096,
+            ram='8096M',
             smp=4
         )
 

--- a/test/unit/plugin_config_test.py
+++ b/test/unit/plugin_config_test.py
@@ -29,7 +29,7 @@ class TestPluginConfig:
         assert self.plugin_config.get_config() == [
             {
                 'name': 'suse',
-                'mem_mb': 8096,
+                'mem_mb': '8096M',
                 'processors': 4,
                 'console': 'hvc0',
                 'arch': [
@@ -51,7 +51,7 @@ class TestPluginConfig:
             },
             {
                 'name': 'universal',
-                'mem_mb': 8096,
+                'mem_mb': '8096M',
                 'processors': 4,
                 'console': 'hvc0',
                 'arch': [


### PR DESCRIPTION
Switch to virtiofsd v>=1.10 and adapted caller options as well as the memory settings which requires a unit information to properly match the numa sockets with the main memory