### PR TITLE
Fix Ubuntu box build

### DIFF
--- a/boxes/ubuntu/appliance.kiwi
+++ b/boxes/ubuntu/appliance.kiwi
@@ -106,14 +106,15 @@
         <archive name="box-key-unsafe.tgz"/>
     </packages>
     <packages type="bootstrap">
+        <package name="locales"/>
+        <package name="coreutils"/>
+        <package name="language-pack-en"/>
+        <package name="passwd"/>
+        <package name="base-passwd"/>
+        <package name="adduser"/>
+        <package name="debconf"/>
         <package name="ca-certificates"/>
-        <package name="bash-completion"/>
         <package name="apt-utils"/>
         <package name="debconf-i18n"/>
-        <package name="libnss-nis"/>
-        <package name="libnss-nisplus"/>
-        <package name="libgpg-error-l10n"/>
-        <package name="uuid-runtime"/>
-        <package name="sensible-utils"/>
     </packages>
 </image>

--- a/boxes/ubuntu/post_bootstrap.sh
+++ b/boxes/ubuntu/post_bootstrap.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -ex
+
+# Intermediate C locale setup
+export LANG=C.UTF-8
+export LANGUAGE=
+
+# Intermediate Noninteractive debconf
+echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+# Download packages for which we need the script code
+apt-get -q -c /kiwi_apt.conf -y --no-install-recommends install \
+    "-oDebug::pkgDPkgPm=1" "-oDPkg::Pre-Install-Pkgs::=cat >/tmp/postpacks" \
+base-passwd
+
+# Run package scripts for core OS packages which provides
+# mandatory setup code in their pre/post scripts
+export DPKG_ROOT=/
+while read -r package;do
+    pushd "$(dirname "${package}")" || exit 1
+    if [ "$(basename "${package}")" = "base-passwd.deb" ];then
+        # Required to create passwd, groups, the root user...
+        dpkg -e "${package}"
+        test -e DEBIAN/preinst && bash DEBIAN/preinst install
+        test -e DEBIAN/postinst && bash DEBIAN/postinst
+        rm -rf DEBIAN
+    fi
+    popd || exit 1
+done < /tmp/postpacks
+rm -f /tmp/postpacks


### PR DESCRIPTION
Add post_bootstrap.sh and make sure the package scripts for passwd-base run. Depending on what other packages gets installed it might be required to enter the system package installation with a proper setup because otherwise package scripts from other packages will fail. We might consider to add this code into kiwi though