### PR TITLE
allow to override default boxes cache location

### DIFF
--- a/doc/source/commands/system_boxbuild.rst
+++ b/doc/source/commands/system_boxbuild.rst
@@ -174,6 +174,15 @@ OPTIONS
    the virtual machine. See the Example below how to provide
    options to the build command correctly.
 
+ENVIRONMENT
+-----------
+
+KIWI_BOXED_CACHE_DIR
+   By default, VM disk images used as build environment are
+   stored in $HOME/.kiwi_boxes directory. To override this
+   location, KIWI_BOXED_CACHE_DIR environment variable should
+   be set to a different absolute path.
+
 EXAMPLE
 -------
 

--- a/kiwi_boxed_plugin/defaults.py
+++ b/kiwi_boxed_plugin/defaults.py
@@ -79,6 +79,9 @@ class Defaults:
 
     @staticmethod
     def get_local_box_cache_dir() -> str:
+        local_box_cache_dir_env: str | None = os.environ.get("KIWI_BOXED_CACHE_DIR")
+        if local_box_cache_dir_env is not None and os.path.exists(local_box_cache_dir_env):
+            return local_box_cache_dir_env
         return f'{os.environ.get("HOME")}/.kiwi_boxes'
 
     @staticmethod

--- a/kiwi_boxed_plugin/defaults.py
+++ b/kiwi_boxed_plugin/defaults.py
@@ -17,7 +17,9 @@
 #
 import os
 import pathlib
-from typing import List
+from typing import (
+    List, Optional
+)
 from kiwi.path import Path
 from pkg_resources import resource_filename
 import subprocess
@@ -79,8 +81,10 @@ class Defaults:
 
     @staticmethod
     def get_local_box_cache_dir() -> str:
-        local_box_cache_dir_env: str | None = os.environ.get("KIWI_BOXED_CACHE_DIR")
-        if local_box_cache_dir_env is not None and os.path.exists(local_box_cache_dir_env):
+        local_box_cache_dir_env: Optional[str] = os.environ.get(
+            'KIWI_BOXED_CACHE_DIR'
+        )
+        if local_box_cache_dir_env and os.path.isdir(local_box_cache_dir_env):
             return local_box_cache_dir_env
         return f'{os.environ.get("HOME")}/.kiwi_boxes'
 

--- a/test/unit/box_download_test.py
+++ b/test/unit/box_download_test.py
@@ -42,6 +42,25 @@ class TestBoxDownload:
     ):
         self.setup()
 
+    @patch('kiwi_boxed_plugin.defaults.Defaults.get_plugin_config_file')
+    @patch('kiwi_boxed_plugin.box_download.Path')
+    @patch('kiwi_boxed_plugin.box_download.DirFiles')
+    @patch('os.path.isdir')
+    def test_custom_box_cache_dir(
+        self, mock_os_path_isdir, mock_DirFiles, mock_Path,
+        mock_get_plugin_config_file
+    ):
+        mock_os_path_isdir.return_value = True
+        mock_DirFiles.return_value = \
+            Mock().register.return_value = 'register_file'
+        mock_get_plugin_config_file.return_value = \
+            '../data/kiwi_boxed_plugin.yml'
+        with patch.dict('os.environ', {'KIWI_BOXED_CACHE_DIR': '/some/custom/dir'}):
+            BoxDownload('suse', 'x86_64')
+        mock_Path.create.assert_called_once_with(
+            '/some/custom/dir/suse'
+        )
+
     @patch('kiwi_boxed_plugin.box_download.Command.run')
     @patch('kiwi_boxed_plugin.box_download.Uri')
     @patch('kiwi_boxed_plugin.box_download.SolverRepository.new')


### PR DESCRIPTION
If KIWI_BOXED_CACHE_DIR environment variable is set, it will be used to store kiwi boxes used for build.