### PR TITLE
Fix shellcheck for SC2317

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -109,7 +109,7 @@ usedevelop = True
 commands =
     flake8 --statistics -j auto --count {toxinidir}/kiwi_boxed_plugin
     flake8 --statistics -j auto --count {toxinidir}/test/unit
-    bash -c 'shellcheck -e SC1091 {toxinidir}/boxes/images.sh -e SC2086 -s bash'
+    bash -c 'shellcheck -e SC1091,SC2317,SC2086 {toxinidir}/boxes/images.sh -s bash'
 
 
 # PyPi upload


### PR DESCRIPTION
SC2317 is issued on commands considered no reachable. However, for the special images.sh script this test is a false positive and can be ignored.