### PR TITLE
Make sure to run with exported PATH setting

### DIFF
--- a/boxes/images.sh
+++ b/boxes/images.sh
@@ -31,6 +31,7 @@ function run_build {
     rm -rf /result
     options=$(cut -f2 -d\" /proc/cmdline)
     options="${options} --description /description --target-dir /result"
+    export PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin
     if kiwi-ng --logfile "${logfile}" ${options}; then
         kiwi-ng result bundle --id 0 --target-dir /result --bundle-dir /bundle
     fi


### PR DESCRIPTION
The kiwi run inside of the box runs from an environment that has no PATH setup. This can lead to issues when Path.which() is used to find program files in the box and also as base for the search inside of the new root tree. If no PATH is set kiwi uses os.defpath which does not take enough paths (e.g /usr/sbin) into account. This commit makes sure we run kiwi with a proper PATH setup.