### PR TITLE
Fix deps for packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,8 @@ kiwi = ">=9.21.21"
 docopt-ng = ">=0.9.0"
 requests = ">=2.25.0"
 PyYAML = ">=5.4.0"
-Cerberus = ">=1.3.5"
-progressbar2 = ">=4.2.0"
+Cerberus = ">=1.3.0"
+progressbar2 = ">=3.53"
 
 [tool.poetry.plugins]
 [tool.poetry.plugins."kiwi.tasks"]


### PR DESCRIPTION
This fixes it so we can build for RHEL 9 (which is still supported).