### PR TITLE
Add container support to boxbuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ python_version = 3
 python_lookup_name = python$(python_version)
 python = $(shell which $(python_lookup_name))
 docdir = /usr/share/doc/packages
+sc_disable = SC1091,SC2086,SC2317
 
 version := $(shell \
 	$(python) -c \
@@ -29,6 +30,8 @@ docs: setup
 	poetry run make -C doc man
 
 check: setup
+	# shell code checks
+	bash -c 'shellcheck -e ${sc_disable} boxes/images.sh -s bash'
 	# python flake tests
 	poetry run flake8 --statistics -j auto --count kiwi_boxed_plugin
 	poetry run flake8 --statistics -j auto --count test/unit

--- a/boxes/fedora/appliance.kiwi
+++ b/boxes/fedora/appliance.kiwi
@@ -12,6 +12,7 @@
     <profiles>
         <profile name="Kernel" description="Provides kernel for kvm boot"/>
         <profile name="System" description="Provides system for kvm boot"/>
+        <profile name="Container" description="Provides system for podman"/>
     </profiles>
     <preferences>
         <version>1.39.1</version>
@@ -21,6 +22,13 @@
         <timezone>UTC</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
+    </preferences>
+    <preferences profiles="Container">
+        <type image="docker">
+            <containerconfig name="fedora">
+                <entrypoint execute="/usr/lib/systemd/systemd"/>
+            </containerconfig>
+        </type>
     </preferences>
     <preferences profiles="Kernel">
         <type image="pxe" initrd_system="dracut"/>
@@ -48,7 +56,6 @@
         <package name="dhclient"/>
         <package name="glibc-all-langpacks"/>
         <package name="tzdata"/>
-        <package name="NetworkManager"/>
         <package name="dbus-daemon"/>
         <package name="lvm2"/>
         <package name="xfsprogs"/>
@@ -77,6 +84,7 @@
         <package name="fuse-common"/>
         <package name="netcat"/>
         <package name="systemd-resolved"/>
+        <package name="systemd-networkd"/>
         <package name="audit"/>
         <package name="distribution-gpg-keys"/>
         <archive name="box-key-unsafe.tgz"/>

--- a/boxes/fedora/config.sh
+++ b/boxes/fedora/config.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
-
-set -ex
-
-test -f /.kconfig && . /.kconfig
-test -f /.profile && . /.profile
-
-#======================================
-# Setup default target, multi-user
-#--------------------------------------
-baseSetRunlevel 3
+set -eux
 
 #==================================
 # Disable services
@@ -22,10 +13,52 @@ systemctl mask systemd-user-sessions.service
 #======================================
 # Activate kiwi service
 #--------------------------------------
-baseInsertService sshd
-baseInsertService kiwi
+systemctl enable systemd-networkd
+systemctl enable systemd-resolved
+systemctl enable sshd
+systemctl enable kiwi
 
 #======================================
-# Fedora uses systemd-resolved for DNS
+# lvmetad sucks for building lvm images
 #--------------------------------------
-systemctl enable systemd-resolved
+systemctl disable lvm2-lvmetad
+systemctl mask lvm2-lvmetad
+systemctl disable lvm2-lvmetad.socket
+systemctl mask lvm2-lvmetad.socket
+
+#======================================
+# Setup container
+#--------------------------------------
+for profile in ${kiwi_profiles//,/ }; do
+    if [ "${profile}" = "Container" ]; then
+        # Add cache dir
+        mkdir -p /var/cache/kiwi
+
+        # Setup kpartx for container build
+        cat >>/etc/kiwi.yml <<-EOF
+
+		mapper:
+		  - part_mapper: kpartx
+		EOF
+
+        # Create login call
+        cat >>/etc/bashrc <<-EOF
+
+		journalctl -u kiwi -f
+		EOF
+        chmod 755 /etc/bashrc
+
+        # Disable services not useful in a container
+        systemctl disable sshd
+        systemctl disable systemd-networkd
+        systemctl disable systemd-resolved
+
+        # Mask services not useful in a container
+        systemctl mask sys-kernel-config.mount
+        systemctl mask sys-kernel-debug.mount
+        systemctl mask sys-kernel-tracing.mount
+        systemctl mask systemd-resolved
+        systemctl mask systemd-networkd
+        systemctl mask systemd-modules-load
+    fi
+done

--- a/boxes/fedora/root/etc/sysconfig/network-scripts/ifcfg-lan0
+++ b/boxes/fedora/root/etc/sysconfig/network-scripts/ifcfg-lan0
@@ -1,5 +1,0 @@
-DEVICE="lan0"
-BOOTPROTO="dhcp"
-ONBOOT="yes"
-TYPE="Ethernet"
-PERSISTENT_DHCLIENT="yes"

--- a/boxes/fedora/root/etc/systemd/network/20-local.network
+++ b/boxes/fedora/root/etc/systemd/network/20-local.network
@@ -1,0 +1,8 @@
+[Match]
+Name=lan0
+
+[Network]
+DHCP=yes
+
+[DHCP]
+ClientIdentifier=mac

--- a/boxes/fedora/root/etc/systemd/system/console-getty.service.d/override.conf
+++ b/boxes/fedora/root/etc/systemd/system/console-getty.service.d/override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin root --noclear --keep-baud 115200,38400,9600 console $TERM

--- a/boxes/fedora/root/usr/lib/systemd/system/kiwi.service
+++ b/boxes/fedora/root/usr/lib/systemd/system/kiwi.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Start kiwi build process
-After=network.target
+After=network-online.target
 Requires=network-online.target
 
 [Service]

--- a/boxes/leap/appliance.kiwi
+++ b/boxes/leap/appliance.kiwi
@@ -12,6 +12,7 @@
     <profiles>
         <profile name="Kernel" description="Provides kernel for kvm boot"/>
         <profile name="System" description="Provides system for kvm boot"/>
+        <profile name="Container" description="Provides system for podman"/>
     </profiles>
     <preferences>
         <version>1.15.5</version>
@@ -21,6 +22,13 @@
         <timezone>UTC</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
+    </preferences>
+    <preferences profiles="Container">
+        <type image="docker">
+            <containerconfig name="leap">
+                <entrypoint execute="/usr/lib/systemd/systemd"/>
+            </containerconfig>
+        </type>
     </preferences>
     <preferences profiles="Kernel">
         <type image="pxe" initrd_system="dracut"/>
@@ -42,10 +50,9 @@
     </repository>
     <packages type="image">
         <package name="patterns-base-minimal_base"/>
-        <package name="wicked"/>
-        <package name="wicked-service"/>
         <package name="plymouth-scripts"/>
         <package name="timezone"/>
+        <package name="systemd-network"/>
         <package name="systemd"/>
         <package name="grub2"/>
         <package name="grub2-i386-pc"/>

--- a/boxes/leap/root/etc/sysconfig/network/ifcfg-lan0
+++ b/boxes/leap/root/etc/sysconfig/network/ifcfg-lan0
@@ -1,4 +1,0 @@
-BOOTPROTO='dhcp'
-MTU=''
-REMOTE_IPADDR=''
-STARTMODE='onboot'

--- a/boxes/leap/root/etc/systemd/network/20-local.network
+++ b/boxes/leap/root/etc/systemd/network/20-local.network
@@ -1,0 +1,8 @@
+[Match]
+Name=lan0
+
+[Network]
+DHCP=yes
+
+[DHCP]
+ClientIdentifier=mac

--- a/boxes/leap/root/etc/systemd/system/console-getty.service.d/override.conf
+++ b/boxes/leap/root/etc/systemd/system/console-getty.service.d/override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin root --noclear --keep-baud 115200,38400,9600 console $TERM

--- a/boxes/leap/root/usr/lib/systemd/system/kiwi.service
+++ b/boxes/leap/root/usr/lib/systemd/system/kiwi.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Start kiwi build process
-After=network.target
+After=network-online.target
 Requires=network-online.target
 
 [Service]

--- a/boxes/tumbleweed/appliance.kiwi
+++ b/boxes/tumbleweed/appliance.kiwi
@@ -12,6 +12,7 @@
     <profiles>
         <profile name="Kernel" description="Provides kernel for kvm boot"/>
         <profile name="System" description="Provides system for kvm boot"/>
+        <profile name="Container" description="Provides system for podman"/>
     </profiles>
     <preferences>
         <version>1.43.3</version>
@@ -21,6 +22,13 @@
         <timezone>UTC</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
+    </preferences>
+    <preferences profiles="Container">
+        <type image="docker">
+            <containerconfig name="tumbleweed">
+                <entrypoint execute="/usr/lib/systemd/systemd"/>
+            </containerconfig>
+        </type>
     </preferences>
     <preferences profiles="Kernel">
         <type image="pxe" initrd_system="dracut"/>
@@ -51,10 +59,9 @@
     <packages type="image">
         <package name="patterns-base-minimal_base"/>
         <package name="aaa_base"/>
-        <package name="wicked"/>
-        <package name="wicked-service"/>
         <package name="plymouth-scripts"/>
         <package name="timezone"/>
+        <package name="systemd-network"/>
         <package name="systemd"/>
         <package name="grub2"/>
         <package name="shim" arch="x86_64"/>

--- a/boxes/tumbleweed/config.sh
+++ b/boxes/tumbleweed/config.sh
@@ -1,16 +1,5 @@
 #!/bin/bash
-test -f /.kconfig && . /.kconfig
-test -f /.profile && . /.profile
-
-#======================================
-# Setup baseproduct link
-#--------------------------------------
-suseSetupProduct
-
-#======================================
-# Setup default target, multi-user
-#--------------------------------------
-baseSetRunlevel 3
+set -eux
 
 #==================================
 # Disable services
@@ -24,8 +13,10 @@ systemctl mask systemd-user-sessions.service
 #======================================
 # Activate kiwi service
 #--------------------------------------
-suseInsertService sshd
-suseInsertService kiwi
+systemctl enable systemd-networkd
+systemctl enable systemd-resolved
+systemctl enable sshd
+systemctl enable kiwi
 
 #======================================
 # lvmetad sucks for building lvm images
@@ -34,3 +25,45 @@ systemctl disable lvm2-lvmetad
 systemctl mask lvm2-lvmetad
 systemctl disable lvm2-lvmetad.socket
 systemctl mask lvm2-lvmetad.socket
+
+#======================================
+# Setup container
+#--------------------------------------
+for profile in ${kiwi_profiles//,/ }; do
+    if [ "${profile}" = "Container" ]; then
+        # Add cache dir
+        mkdir -p /var/cache/kiwi
+
+        # Setup kpartx for container build
+        cat >>/etc/kiwi.yml <<-EOF
+
+		mapper:
+		  - part_mapper: kpartx
+		EOF
+
+        # Setup journal config in container
+        cat >/etc/systemd/journald.conf.d/volatile.conf <<-EOF
+		[Journal]
+		Storage=volatile
+		EOF
+
+        # Create login call
+        cat >/root/.bashrc <<-EOF
+		journalctl -u kiwi -f
+		EOF
+        chmod 755 /root/.bashrc
+
+        # Disable services not useful in a container
+        systemctl disable sshd
+        systemctl disable systemd-networkd
+        systemctl disable systemd-resolved
+
+        # Mask services not useful in a container
+        systemctl mask sys-kernel-config.mount
+        systemctl mask sys-kernel-debug.mount
+        systemctl mask sys-kernel-tracing.mount
+        systemctl mask systemd-resolved
+        systemctl mask systemd-networkd
+        systemctl mask systemd-modules-load
+    fi
+done

--- a/boxes/tumbleweed/root/etc/sysconfig/network/ifcfg-lan0
+++ b/boxes/tumbleweed/root/etc/sysconfig/network/ifcfg-lan0
@@ -1,4 +1,0 @@
-BOOTPROTO='dhcp'
-MTU=''
-REMOTE_IPADDR=''
-STARTMODE='onboot'

--- a/boxes/tumbleweed/root/etc/systemd/network/20-local.network
+++ b/boxes/tumbleweed/root/etc/systemd/network/20-local.network
@@ -1,0 +1,8 @@
+[Match]
+Name=lan0
+
+[Network]
+DHCP=yes
+
+[DHCP]
+ClientIdentifier=mac

--- a/boxes/tumbleweed/root/etc/systemd/system/console-getty.service.d/override.conf
+++ b/boxes/tumbleweed/root/etc/systemd/system/console-getty.service.d/override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin root --noclear --keep-baud 115200,38400,9600 console $TERM

--- a/boxes/tumbleweed/root/usr/lib/systemd/system/kiwi.service
+++ b/boxes/tumbleweed/root/usr/lib/systemd/system/kiwi.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Start kiwi build process
-After=network.target
+After=network-online.target
 Requires=network-online.target
 
 [Service]

--- a/boxes/ubuntu/appliance.kiwi
+++ b/boxes/ubuntu/appliance.kiwi
@@ -12,6 +12,7 @@
     <profiles>
         <profile name="Kernel" description="Provides kernel for kvm boot"/>
         <profile name="System" description="Provides system for kvm boot"/>
+        <profile name="Container" description="Provides system for podman"/>
     </profiles>
     <preferences>
         <version>1.24.4</version>
@@ -19,6 +20,13 @@
         <locale>en_US</locale>
         <timezone>UTC</timezone>
         <rpm-check-signatures>false</rpm-check-signatures>
+    </preferences>
+    <preferences profiles="Container">
+        <type image="docker">
+            <containerconfig name="ubuntu">
+                <entrypoint execute="/usr/lib/systemd/systemd"/>
+            </containerconfig>
+        </type>
     </preferences>
     <preferences profiles="Kernel">
         <type image="pxe" initrd_system="dracut"/>

--- a/boxes/ubuntu/config.sh
+++ b/boxes/ubuntu/config.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
-
-set -x
-
-test -f /.kconfig && . /.kconfig
-test -f /.profile && . /.profile
-
-#======================================
-# Setup default target, multi-user
-#--------------------------------------
-baseSetRunlevel 3
+set -eux
 
 #==================================
 # Disable services
@@ -22,19 +13,43 @@ systemctl mask systemd-user-sessions.service
 #======================================
 # Activate kiwi service
 #--------------------------------------
-baseInsertService ssh
-baseInsertService kiwi
+systemctl enable systemd-networkd
+systemctl enable systemd-resolved
+systemctl enable ssh
+systemctl enable kiwi
 
 #======================================
-# lvmetad sucks for building lvm images
+# Setup container
 #--------------------------------------
-systemctl disable lvm2-lvmetad
-systemctl mask lvm2-lvmetad
-systemctl disable lvm2-lvmetad.socket
-systemctl mask lvm2-lvmetad.socket
+for profile in ${kiwi_profiles//,/ }; do
+    if [ "${profile}" = "Container" ]; then
+        # Add cache dir
+        mkdir -p /var/cache/kiwi
 
-#======================================
-# Enable systemd networking services
-#--------------------------------------
-baseInsertService systemd-networkd
-baseInsertService systemd-resolved
+        # Setup kpartx for container build
+        cat >>/etc/kiwi.yml <<-EOF
+
+		mapper:
+		  - part_mapper: kpartx
+		EOF
+
+        # Create login call
+        cat >/root/.bashrc <<-EOF
+		journalctl -u kiwi -f
+		EOF
+        chmod 755 /root/.bashrc
+
+        # Disable services not useful in a container
+        systemctl disable ssh
+        systemctl disable systemd-networkd
+        systemctl disable systemd-resolved
+
+        # Mask services not useful in a container
+        systemctl mask sys-kernel-config.mount
+        systemctl mask sys-kernel-debug.mount
+        systemctl mask sys-kernel-tracing.mount
+        systemctl mask systemd-resolved
+        systemctl mask systemd-networkd
+        systemctl mask systemd-modules-load
+    fi
+done

--- a/boxes/ubuntu/root/etc/systemd/system/console-getty.service.d/override.conf
+++ b/boxes/ubuntu/root/etc/systemd/system/console-getty.service.d/override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin root --noclear --keep-baud 115200,38400,9600 console $TERM

--- a/boxes/ubuntu/root/usr/lib/systemd/system/kiwi.service
+++ b/boxes/ubuntu/root/usr/lib/systemd/system/kiwi.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Start kiwi build process
-After=network.target
+After=network-online.target
 Requires=network-online.target
 
 [Service]

--- a/boxes/universal/appliance.kiwi
+++ b/boxes/universal/appliance.kiwi
@@ -12,6 +12,7 @@
     <profiles>
         <profile name="Kernel" description="Provides kernel for kvm boot"/>
         <profile name="System" description="Provides system for kvm boot"/>
+        <profile name="Container" description="Provides system for podman"/>
     </profiles>
     <preferences>
         <version>1.41.2</version>
@@ -21,6 +22,13 @@
         <timezone>UTC</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
+    </preferences>
+    <preferences profiles="Container">
+        <type image="docker">
+            <containerconfig name="universal">
+                <entrypoint execute="/usr/lib/systemd/systemd"/>
+            </containerconfig>
+        </type>
     </preferences>
     <preferences profiles="Kernel">
         <type image="pxe" initrd_system="dracut"/>
@@ -65,7 +73,6 @@
         <package name="dhclient"/>
         <package name="glibc-all-langpacks"/>
         <package name="tzdata"/>
-        <package name="NetworkManager"/>
         <package name="dbus-daemon"/>
         <package name="lvm2"/>
         <package name="xfsprogs"/>
@@ -109,6 +116,7 @@
         <package name="netcat"/>
         <package name="zstd"/>
         <package name="systemd-resolved"/>
+        <package name="systemd-networkd"/>
         <package name="audit"/>
         <package name="eif_build"/>
         <package name="distribution-gpg-keys"/>

--- a/boxes/universal/config.sh
+++ b/boxes/universal/config.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
-
-set -ex
-
-test -f /.kconfig && . /.kconfig
-test -f /.profile && . /.profile
-
-#======================================
-# Setup default target, multi-user
-#--------------------------------------
-baseSetRunlevel 3
+set -eux
 
 #==================================
 # Disable services
@@ -22,10 +13,52 @@ systemctl mask systemd-user-sessions.service
 #======================================
 # Activate kiwi service
 #--------------------------------------
-baseInsertService sshd
-baseInsertService kiwi
+systemctl enable systemd-networkd
+systemctl enable systemd-resolved
+systemctl enable sshd
+systemctl enable kiwi
 
 #======================================
-# Fedora uses systemd-resolved for DNS
+# lvmetad sucks for building lvm images
 #--------------------------------------
-systemctl enable systemd-resolved
+systemctl disable lvm2-lvmetad
+systemctl mask lvm2-lvmetad
+systemctl disable lvm2-lvmetad.socket
+systemctl mask lvm2-lvmetad.socket
+
+#======================================
+# Setup container
+#--------------------------------------
+for profile in ${kiwi_profiles//,/ }; do
+    if [ "${profile}" = "Container" ]; then
+        # Add cache dir
+        mkdir -p /var/cache/kiwi
+
+        # Setup kpartx for container build
+        cat >>/etc/kiwi.yml <<-EOF
+
+		mapper:
+		  - part_mapper: kpartx
+		EOF
+
+        # Create login call
+        cat >>/etc/bashrc <<-EOF
+
+		journalctl -u kiwi -f
+		EOF
+        chmod 755 /etc/bashrc
+
+        # Disable services not useful in a container
+        systemctl disable sshd
+        systemctl disable systemd-networkd
+        systemctl disable systemd-resolved
+
+        # Mask services not useful in a container
+        systemctl mask sys-kernel-config.mount
+        systemctl mask sys-kernel-debug.mount
+        systemctl mask sys-kernel-tracing.mount
+        systemctl mask systemd-resolved
+        systemctl mask systemd-networkd
+        systemctl mask systemd-modules-load
+    fi
+done

--- a/boxes/universal/root/etc/sysconfig/network-scripts/ifcfg-lan0
+++ b/boxes/universal/root/etc/sysconfig/network-scripts/ifcfg-lan0
@@ -1,5 +1,0 @@
-DEVICE="lan0"
-BOOTPROTO="dhcp"
-ONBOOT="yes"
-TYPE="Ethernet"
-PERSISTENT_DHCLIENT="yes"

--- a/boxes/universal/root/etc/systemd/network/20-local.network
+++ b/boxes/universal/root/etc/systemd/network/20-local.network
@@ -1,0 +1,8 @@
+[Match]
+Name=lan0
+
+[Network]
+DHCP=yes
+
+[DHCP]
+ClientIdentifier=mac

--- a/boxes/universal/root/etc/systemd/system/console-getty.service.d/override.conf
+++ b/boxes/universal/root/etc/systemd/system/console-getty.service.d/override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin root --noclear --keep-baud 115200,38400,9600 console $TERM

--- a/boxes/universal/root/usr/lib/systemd/system/kiwi.service
+++ b/boxes/universal/root/usr/lib/systemd/system/kiwi.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Start kiwi build process
-After=network.target
+After=network-online.target
 Requires=network-online.target
 
 [Service]

--- a/doc/source/commands/system_boxbuild.rst
+++ b/doc/source/commands/system_boxbuild.rst
@@ -14,6 +14,7 @@ SYNOPSIS
        [--box-console=<ttyname>]
        [--box-smp-cpus=<number>]
        [--box-debug]
+       [--container]
        [--kiwi-version=<version>]
        [--shared-path=<path>]
        [--no-update-check]
@@ -21,6 +22,7 @@ SYNOPSIS
        [--no-accel]
        [--9p-sharing | --virtiofs-sharing | --sshfs-sharing]
        [--ssh-key=<name>]
+       [--ssh-port=<port>]
        [--x86_64 | --aarch64]
        [--machine=<qemu_machine>]
        [--cpu=<qemu_cpu>]
@@ -86,6 +88,11 @@ OPTIONS
   Number of CPUs to use in the SMP setup. By default
   4 CPUs will be used
 
+--container
+
+  Build in container instead of a VM. Options related to
+  building in a VM will have no effect.
+
 --no-update-check
 
   Skip check for available box update. The option has no
@@ -120,6 +127,11 @@ OPTIONS
 
   Name of ssh key to authorize for connection.
   By default 'id_rsa' is used.
+
+--ssh-port=<port>
+
+  Port number to use to forward the guest's SSH port to the host
+  By default '10022' is used.
 
 --x86_64|--aarch64
 

--- a/kiwi_boxed_plugin/box_build.py
+++ b/kiwi_boxed_plugin/box_build.py
@@ -33,6 +33,7 @@ from kiwi_boxed_plugin.defaults import Defaults
 import kiwi_boxed_plugin.defaults as runtime
 
 from kiwi_boxed_plugin.exceptions import (
+    KiwiBoxPluginDownloadError,
     KiwiBoxPluginQEMUBinaryNotFound,
     KiwiBoxPluginSSHPortInvalid,
     KiwiError
@@ -108,7 +109,12 @@ class BoxBuild:
             '--target-dir'
         )
         Path.create(target_dir)
-        vm_setup = self.box.fetch(update_check)
+        try:
+            vm_setup = self.box.fetch(update_check)
+        except Exception as issue:
+            raise KiwiBoxPluginDownloadError(
+                f'Failed to fetch box file(s): {issue}'
+            )
         vm_append = [
             vm_setup.append,
             'kiwi=\\"{0}\\"'.format(' '.join(self.kiwi_build_command))

--- a/kiwi_boxed_plugin/box_config.py
+++ b/kiwi_boxed_plugin/box_config.py
@@ -65,6 +65,9 @@ class BoxConfig:
     def get_box_source(self) -> str:
         return self.box_arch_config.get('source') or ''
 
+    def get_box_container(self) -> str:
+        return self.box_arch_config.get('container') or ''
+
     def get_box_packages_file(self) -> str:
         return self.box_arch_config.get('packages_file') or ''
 

--- a/kiwi_boxed_plugin/box_container_build.py
+++ b/kiwi_boxed_plugin/box_container_build.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2025 SUSE LLC.  All rights reserved.
+#
+# This file is part of kiwi-boxed-build.
+#
+# kiwi-boxed-build is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi-boxed-build is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi-boxed-build.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+import logging
+import platform
+from tempfile import NamedTemporaryFile
+from typing import (
+    List, Optional
+)
+from kiwi.path import Path
+
+from kiwi_boxed_plugin.box_download import BoxDownload
+from kiwi_boxed_plugin.exceptions import (
+    KiwiError
+)
+
+log = logging.getLogger('kiwi')
+
+
+class BoxContainerBuild:
+    """
+    **Implements boxbuild command for container based build**
+
+    Implements an interface to run a kiwi build box using
+    the podman container engine
+
+    :param str boxname: name of the box from kiwi_boxed_plugin.yml
+    :param str arch: arch name for box
+    """
+    def __init__(
+        self, boxname: str, arch: str = ''
+    ) -> None:
+        self.arch = arch or platform.machine()
+        self.box = BoxDownload(boxname, arch)
+        self.kiwi_exit: Optional[int] = None
+
+    def run(
+        self, kiwi_build_command: List[str],
+        keep_open: bool = False, kiwi_version: str = '',
+        custom_shared_path: str = ''
+    ) -> None:
+        """
+        Start the build process in a container
+
+        :param list kiwi_build_command:
+            kiwi build command line Example:
+
+            .. code:: python
+
+                [
+                    '--type', 'oem', 'system', 'build',
+                    '--description', 'some/description',
+                    '--target-dir', 'some/target-dir'
+                ]
+
+        :param bool keep_open: keep container running True|False
+        :param str kiwi_version: pip install this kiwi version
+        :param str custom_shared_path: make this path available in the container
+        """
+        self.kiwi_build_command = kiwi_build_command
+        desc = self._pop_arg_param(
+            '--description'
+        )
+        target_dir = self._pop_arg_param(
+            '--target-dir'
+        )
+        Path.create(target_dir)
+
+        container_name = self.box.fetch_container()
+
+        container_cmdline = [
+            'kiwi="{0}"'.format(' '.join(self.kiwi_build_command))
+        ]
+        if keep_open:
+            container_cmdline.append('kiwi-no-halt')
+        if kiwi_version:
+            container_cmdline.append(
+                'kiwi_version=_{0}_'.format(kiwi_version)
+            )
+        if custom_shared_path:
+            container_cmdline.append(
+                'custom_mount=_{0}_'.format(custom_shared_path)
+            )
+
+        self.cmdline = NamedTemporaryFile(prefix='cmdline')
+        with open(self.cmdline.name, 'w') as cmdline:
+            cmdline.write('{0}'.format(' '.join(container_cmdline)))
+            cmdline.write(os.linesep)
+
+        Path.create('/var/cache/kiwi')
+        container_run = [
+            'sudo', 'podman', 'run',
+            '--rm',
+            '-ti',
+            '--privileged',
+            '--net', 'host',
+            '--cap-add', 'AUDIT_WRITE',
+            '--cap-add', 'AUDIT_CONTROL',
+            '--cap-add', 'CAP_MKNOD',
+            '--cap-add', 'CAP_SYS_ADMIN',
+            '--volume', '/var/cache/kiwi:/var/cache/kiwi',
+            '--volume', f'{self.cmdline.name}:/container.cmdline',
+            '--volume', f'{target_dir}:/bundle',
+            '--volume', f'{desc}:/description',
+            '--volume', '/dev:/dev'
+        ]
+        if custom_shared_path:
+            container_run.append('--volume')
+            container_run.append(f'{custom_shared_path}:{custom_shared_path}')
+        container_run.append(container_name)
+
+        log.debug(
+            'Calling podman: {0}'.format(container_run)
+        )
+        os.system(
+            ' '.join(container_run)
+        )
+
+        exit_code_file = os.sep.join([target_dir, 'result.code'])
+        build_log_file = os.sep.join([target_dir, 'result.log'])
+        self.kiwi_exit = 0
+        if os.path.exists(exit_code_file):
+            with open(exit_code_file) as exit_code:
+                self.kiwi_exit = int(exit_code.readline())
+
+        if self.kiwi_exit != 0:
+            raise KiwiError(
+                f'Box build failed. Find build log at: {build_log_file!r}'
+            )
+
+        log.info(
+            f'Box build done. Find build log at: {build_log_file!r}'
+        )
+
+    def _pop_arg_param(self, arg: str) -> str:
+        arg_index = self.kiwi_build_command.index(arg)
+        arg_value = ''
+        if arg_index:
+            arg_value = self.kiwi_build_command[arg_index + 1]
+            del self.kiwi_build_command[arg_index + 1]
+            del self.kiwi_build_command[arg_index]
+        return arg_value

--- a/kiwi_boxed_plugin/box_download.py
+++ b/kiwi_boxed_plugin/box_download.py
@@ -29,7 +29,9 @@ from kiwi.path import Path
 
 from kiwi_boxed_plugin.box_config import BoxConfig
 from kiwi_boxed_plugin.defaults import Defaults
-from kiwi_boxed_plugin.exceptions import KiwiBoxPluginChecksumError
+from kiwi_boxed_plugin.exceptions import (
+    KiwiBoxPluginChecksumError
+)
 
 vm_setup_type = NamedTuple(
     'vm_setup_type', [
@@ -67,6 +69,20 @@ class BoxDownload:
         self.kernel = ''
         self.initrd = ''
         Path.create(self.box_dir)
+
+    def fetch_container(self) -> str:
+        """
+        Download container box from the open build service
+        """
+        container_source = self.box_config.get_box_container()
+        if container_source:
+            container_pull = [
+                'sudo', 'podman', 'pull', container_source
+            ]
+            os.system(
+                ' '.join(container_pull)
+            )
+        return container_source
 
     def fetch(self, update_check: bool = True) -> vm_setup_type:
         """

--- a/kiwi_boxed_plugin/config/kiwi_boxed_plugin.yml
+++ b/kiwi_boxed_plugin/config/kiwi_boxed_plugin.yml
@@ -15,6 +15,7 @@ box:
         boxfiles:
           - TumbleWeed-Box.x86_64-Kernel.tar.xz
           - TumbleWeed-Box.x86_64-System.qcow2
+        container: registry.opensuse.org/virtualization/appliances/selfcontained/tumbleweed/images/tumbleweed:latest
         use_initrd: true
 
       -
@@ -28,6 +29,7 @@ box:
         boxfiles:
           - TumbleWeed-Box.x86_64-Kernel.tar.xz
           - TumbleWeed-Box.x86_64-System.qcow2
+        container: registry.opensuse.org/virtualization/appliances/selfcontained/tumbleweed/images/tumbleweed:latest
         use_initrd: true
 
       -
@@ -41,6 +43,7 @@ box:
         boxfiles:
           - TumbleWeed-Box.s390x-Kernel.tar.xz
           - TumbleWeed-Box.s390x-System.qcow2
+        container: registry.opensuse.org/virtualization/appliances/selfcontained/tumbleweed/images/tumbleweed:latest
         use_initrd: true
 
   -
@@ -59,6 +62,7 @@ box:
         boxfiles:
           - Leap-Box.x86_64-Kernel.tar.xz
           - Leap-Box.x86_64-System.qcow2
+        container: registry.opensuse.org/virtualization/appliances/selfcontained/leap/images/leap:latest
         use_initrd: true
 
   -
@@ -78,6 +82,7 @@ box:
         boxfiles:
           - Fedora-Box.x86_64-Kernel.tar.xz
           - Fedora-Box.x86_64-System.qcow2
+        container: registry.opensuse.org/virtualization/appliances/selfcontained/fedora/images/fedora:latest
         use_initrd: true
 
   -
@@ -97,6 +102,7 @@ box:
         boxfiles:
           - Ubuntu-Box.x86_64-Kernel.tar.xz
           - Ubuntu-Box.x86_64-System.qcow2
+        container: registry.opensuse.org/virtualization/appliances/selfcontained/ubuntu/images/ubuntu:latest
         use_initrd: true
 
       -
@@ -110,6 +116,7 @@ box:
         boxfiles:
           - Ubuntu-Box.aarch64-Kernel.tar.xz
           - Ubuntu-Box.aarch64-System.qcow2
+        container: registry.opensuse.org/virtualization/appliances/selfcontained/ubuntu/images/ubuntu:latest
         use_initrd: true
 
   -
@@ -129,6 +136,7 @@ box:
         boxfiles:
           - Universal-Box.x86_64-Kernel.tar.xz
           - Universal-Box.x86_64-System.qcow2
+        container: registry.opensuse.org/virtualization/appliances/selfcontained/universal/images/universal:latest
         use_initrd: true
 
       -
@@ -142,6 +150,7 @@ box:
         boxfiles:
           - Universal-Box.aarch64-Kernel.tar.xz
           - Universal-Box.aarch64-System.qcow2
+        container: registry.opensuse.org/virtualization/appliances/selfcontained/universal/images/universal:latest
         use_initrd: true
 
       -
@@ -155,6 +164,7 @@ box:
         boxfiles:
           - Universal-Box.s390x-Kernel.tar.xz
           - Universal-Box.s390x-System.qcow2
+        container: registry.opensuse.org/virtualization/appliances/selfcontained/universal/images/universal:latest
         use_initrd: true
 
       -
@@ -168,4 +178,5 @@ box:
         boxfiles:
           - Universal-Box.ppc64le-Kernel.tar.xz
           - Universal-Box.ppc64le-System.qcow2
+        container: registry.opensuse.org/virtualization/appliances/selfcontained/universal/images/universal:latest
         use_initrd: true

--- a/kiwi_boxed_plugin/exceptions.py
+++ b/kiwi_boxed_plugin/exceptions.py
@@ -59,3 +59,9 @@ class KiwiBoxPluginChecksumError(KiwiError):
     """
     Exception raised in case of a checksum error
     """
+
+
+class KiwiBoxPluginDownloadError(KiwiError):
+    """
+    Exception raised in case of a download issue
+    """

--- a/kiwi_boxed_plugin/plugin_config_schema.py
+++ b/kiwi_boxed_plugin/plugin_config_schema.py
@@ -58,6 +58,11 @@ schema = {
                                 'required': True,
                                 'nullable': False
                             },
+                            'container': {
+                                'type': 'string',
+                                'required': True,
+                                'nullable': False
+                            },
                             'use_initrd': {
                                 'type': 'boolean',
                                 'required': True

--- a/test/data/kiwi_boxed_plugin.yml
+++ b/test/data/kiwi_boxed_plugin.yml
@@ -15,6 +15,7 @@ box:
         boxfiles:
           - SUSE-Box.x86_64-1.42.1-Kernel-BuildBox.tar.xz
           - SUSE-Box.x86_64-1.42.1-System-BuildBox.qcow2
+        container: some
         use_initrd: true
 
   -
@@ -34,6 +35,7 @@ box:
         boxfiles:
           - Universal-Box.x86_64-1.1.2-Kernel-BuildBox.tar.xz
           - Universal-Box.x86_64-1.1.2-System-BuildBox.qcow2
+        container: some
         use_initrd: true
 
       -
@@ -47,4 +49,5 @@ box:
         boxfiles:
           - Universal-Box.aarch64-1.1.2-Kernel-BuildBox.tar.xz
           - Universal-Box.aarch64-1.1.2-System-BuildBox.qcow2
+        container: some
         use_initrd: true

--- a/test/unit/box_build_test.py
+++ b/test/unit/box_build_test.py
@@ -8,6 +8,7 @@ from kiwi_boxed_plugin.box_build import BoxBuild
 import kiwi_boxed_plugin.defaults as defaults
 
 from kiwi_boxed_plugin.exceptions import (
+    KiwiBoxPluginDownloadError,
     KiwiBoxPluginVirtioFsError,
     KiwiBoxPluginQEMUBinaryNotFound,
     KiwiBoxPluginSSHPortInvalid,
@@ -73,6 +74,24 @@ class TestBoxBuild:
         mock_path_which.return_value = 'qemu-system-x86_64'
         self.build.ssh_port = 'bogus'
         with raises(KiwiBoxPluginSSHPortInvalid):
+            self.build.run(
+                [
+                    '--debug', '--type', 'oem', 'system', 'build',
+                    '--description', 'desc', '--target-dir', 'target'
+                ]
+            )
+
+    @patch('os.environ')
+    @patch('os.system')
+    @patch('kiwi_boxed_plugin.box_build.Path.create')
+    @patch('kiwi_boxed_plugin.box_build.Path.which')
+    def test_raises_on_download_error(
+        self, mock_path_which, mock_path_create,
+        mock_os_system, mock_os_environ
+    ):
+        mock_path_which.return_value = 'qemu-system-x86_64'
+        self.box.fetch.side_effect = Exception('error')
+        with raises(KiwiBoxPluginDownloadError):
             self.build.run(
                 [
                     '--debug', '--type', 'oem', 'system', 'build',

--- a/test/unit/box_containerbuild_test.py
+++ b/test/unit/box_containerbuild_test.py
@@ -1,0 +1,78 @@
+import logging
+from unittest.mock import (
+    patch, Mock
+)
+from pytest import raises
+
+from kiwi_boxed_plugin.box_container_build import BoxContainerBuild
+from kiwi_boxed_plugin.exceptions import KiwiError
+
+log = logging.getLogger('kiwi')
+log.setLevel('INFO')
+
+
+class TestBoxContainerBuild:
+    @patch('kiwi_boxed_plugin.box_container_build.BoxDownload')
+    def setup(self, mock_BoxDownload):
+        self.box = Mock()
+        self.box.fetch_container.return_value = 'some'
+        mock_BoxDownload.return_value = self.box
+        self.build = BoxContainerBuild(
+            boxname='suse', arch='x86_64'
+        )
+
+    @patch('kiwi_boxed_plugin.box_container_build.BoxDownload')
+    def setup_method(self, cls, mock_BoxDownload):
+        self.setup()
+
+    @patch('os.environ')
+    @patch('os.system')
+    @patch('kiwi_boxed_plugin.box_container_build.Path.create')
+    def test_raises_on_kiwi_error(
+        self, mock_path_create, mock_os_system, mock_os_environ
+    ):
+        with raises(KiwiError):
+            self.build.run(
+                [
+                    '--type', 'oem', 'system', 'build',
+                    '--description', 'desc', '--target-dir', '../data/target'
+                ]
+            )
+
+    @patch('os.environ')
+    @patch('os.system')
+    @patch('kiwi_boxed_plugin.box_container_build.Path.create')
+    @patch('kiwi_boxed_plugin.box_container_build.NamedTemporaryFile')
+    def test_run(
+        self, mock_NamedTemporaryFile, mock_path_create,
+        mock_os_system, mock_os_environ
+    ):
+        tmpfile = Mock()
+        tmpfile.name = 'tmpfile'
+        mock_NamedTemporaryFile.return_value = tmpfile
+        with patch('builtins.open', create=True):
+            self.build.run(
+                [
+                    '--debug', '--type', 'oem', 'system', 'build',
+                    '--description', 'desc', '--target-dir', 'target'
+                ],
+                keep_open=True,
+                kiwi_version='9.22.1',
+                custom_shared_path='/var/tmp/repos'
+            )
+        mock_os_system.assert_called_once_with(
+            'sudo podman run --rm -ti '
+            '--privileged '
+            '--net host '
+            '--cap-add AUDIT_WRITE '
+            '--cap-add AUDIT_CONTROL '
+            '--cap-add CAP_MKNOD '
+            '--cap-add CAP_SYS_ADMIN '
+            '--volume /var/cache/kiwi:/var/cache/kiwi '
+            '--volume tmpfile:/container.cmdline '
+            '--volume target:/bundle '
+            '--volume desc:/description '
+            '--volume /dev:/dev '
+            '--volume /var/tmp/repos:/var/tmp/repos '
+            'some'
+        )

--- a/test/unit/box_download_test.py
+++ b/test/unit/box_download_test.py
@@ -4,7 +4,9 @@ from unittest.mock import (
     patch, Mock, MagicMock, call
 )
 
-from kiwi_boxed_plugin.exceptions import KiwiBoxPluginChecksumError
+from kiwi_boxed_plugin.exceptions import (
+    KiwiBoxPluginChecksumError
+)
 from kiwi_boxed_plugin.box_download import (
     BoxDownload, vm_setup_type
 )
@@ -57,7 +59,9 @@ class TestBoxDownload:
             Mock().register.return_value = 'register_file'
         mock_get_plugin_config_file.return_value = \
             '../data/kiwi_boxed_plugin.yml'
-        with patch.dict('os.environ', {'KIWI_BOXED_CACHE_DIR': '/some/custom/dir'}):
+        with patch.dict(
+            'os.environ', {'KIWI_BOXED_CACHE_DIR': '/some/custom/dir'}
+        ):
             BoxDownload('suse', 'x86_64')
         mock_Path.create.assert_called_once_with(
             '/some/custom/dir/suse'
@@ -253,3 +257,8 @@ class TestBoxDownload:
     ):
         mock_os_path_exist.return_value = True
         assert self.box.fetch(update_check=False) == self.result
+
+    @patch('os.system')
+    def test_fetch_container(self, mock_os_system):
+        assert self.box.fetch_container() == 'some'
+        mock_os_system.assert_called_once_with('sudo podman pull some')

--- a/test/unit/plugin_config_test.py
+++ b/test/unit/plugin_config_test.py
@@ -25,7 +25,6 @@ class TestPluginConfig:
             PluginConfig()
 
     def test_get_config(self):
-        print(self.plugin_config.get_config())
         assert self.plugin_config.get_config() == [
             {
                 'name': 'suse',
@@ -45,6 +44,7 @@ class TestPluginConfig:
                             'SUSE-Box.x86_64-1.42.1-Kernel-BuildBox.tar.xz',
                             'SUSE-Box.x86_64-1.42.1-System-BuildBox.qcow2'
                         ],
+                        'container': 'some',
                         'use_initrd': True
                     }
                 ]
@@ -69,6 +69,7 @@ class TestPluginConfig:
                             'Universal-Box.x86_64-1.1.2-Kernel-BuildBox.tar.xz',
                             'Universal-Box.x86_64-1.1.2-System-BuildBox.qcow2'
                         ],
+                        'container': 'some',
                         'use_initrd': True
                     },
                     {
@@ -87,6 +88,7 @@ class TestPluginConfig:
                             'Universal-Box.aarch64-1.1.2-'
                             'System-BuildBox.qcow2'
                         ],
+                        'container': 'some',
                         'use_initrd': True
                     }
                 ]

--- a/test/unit/tasks/system_boxbuild_test.py
+++ b/test/unit/tasks/system_boxbuild_test.py
@@ -30,6 +30,7 @@ class TestSystemBoxbuildTask:
         self.task.command_args['help'] = False
         self.task.command_args['boxbuild'] = False
         self.task.command_args['--list-boxes'] = False
+        self.task.command_args['--container'] = False
         self.task.command_args['--box'] = None
         self.task.command_args['--box-debug'] = False
         self.task.command_args['--kiwi-version'] = None
@@ -68,6 +69,28 @@ class TestSystemBoxbuildTask:
         self.task.command_args['--list-boxes'] = True
         self.task.process()
         plugin.dump_config.assert_called_once_with()
+
+    @patch('kiwi_boxed_plugin.tasks.system_boxbuild.BoxContainerBuild')
+    def test_process_system_boxbuild_container(self, mock_BoxContainerBuild):
+        self._init_command_args()
+        self.task.command_args['boxbuild'] = True
+        self.task.command_args['--box'] = 'universal'
+        self.task.command_args['--container'] = True
+        box_containerbuild = Mock()
+        mock_BoxContainerBuild.return_value = box_containerbuild
+        self.task.process()
+        mock_BoxContainerBuild.assert_called_once_with(
+            boxname='universal', arch=''
+        )
+        box_containerbuild.run.assert_called_once_with(
+            [
+                '--debug', '--type', 'oem', '--profile', 'foo',
+                'system', 'build',
+                '--description', 'foo', '--target-dir', 'xxx',
+                '--allow-existing-root',
+                '--add-package', 'a', '--add-package', 'b'
+            ], False, None, None
+        )
 
     @patch('kiwi_boxed_plugin.tasks.system_boxbuild.BoxBuild')
     def test_process_system_boxbuild(self, mock_BoxBuild):


### PR DESCRIPTION
In normal mode boxbuild, builds the image in a KVM virtual machine. With the new --container option, boxbuild can now also build the image in a podman controlled container. The boxes as we have so far received an additional type to also build as containers. In container mode boxbuild pulls the respective container from the remote registry to the local registry and starts a container instance. There are the following runtime constraints:

* As kiwi requires loop devices and can call other operations which requires root privileges, podman is started through sudo. As podman runs daemonless, the calling user must have the privileges to perform the needed kiwi actions. Non privileged builds are therefore not possible in container mode with kiwi.

* The following linux capabilities are added to the container
  - AUDIT_WRITE
  - AUDIT_CONTROL
  - CAP_MKNOD
  - CAP_SYS_ADMIN For details on this capabilities please refer to https://man7.org/linux/man-pages/man7/capabilities.7.html

* The host device nodes (/dev) are shared with the container instance. This is required to work with loop devices inside of the container. Device isolation is therefore not possible in container mode with kiwi.