### PR TITLE
Fix signature check for box system image

### DIFF
--- a/kiwi_boxed_plugin/box_build.py
+++ b/kiwi_boxed_plugin/box_build.py
@@ -110,7 +110,7 @@ class BoxBuild:
         )
         Path.create(target_dir)
         try:
-            vm_setup = self.box.fetch(update_check)
+            vm_setup = self.box.fetch(update_check, snapshot)
         except Exception as issue:
             raise KiwiBoxPluginDownloadError(
                 f'Failed to fetch box file(s): {issue}'

--- a/kiwi_boxed_plugin/box_download.py
+++ b/kiwi_boxed_plugin/box_download.py
@@ -84,7 +84,9 @@ class BoxDownload:
             )
         return container_source
 
-    def fetch(self, update_check: bool = True) -> vm_setup_type:
+    def fetch(
+        self, update_check: bool = True, snapshot: bool = True
+    ) -> vm_setup_type:
         """
         Download box from the open build service
 
@@ -148,13 +150,15 @@ class BoxDownload:
             for box_file in self.box_config.get_box_files():
                 local_box_file = os.sep.join([self.box_dir, box_file])
                 if box_file.endswith('.qcow2'):
-                    if not self._checksum_ok(local_box_file):
+                    if update_check and snapshot and not self._checksum_ok(
+                        local_box_file
+                    ):
                         raise KiwiBoxPluginChecksumError(
                             'Checksum failed for {local_box_file}'
                         )
                     self.system = local_box_file
                 if box_file.endswith('.tar.xz'):
-                    if not self._checksum_ok(local_box_file):
+                    if update_check and not self._checksum_ok(local_box_file):
                         raise KiwiBoxPluginChecksumError(
                             'Checksum failed for {local_box_file}'
                         )

--- a/test/unit/box_download_test.py
+++ b/test/unit/box_download_test.py
@@ -91,7 +91,7 @@ class TestBoxDownload:
         mock_Checksum.return_value = checksum
         with patch('builtins.open', create=True):
             with raises(KiwiBoxPluginChecksumError):
-                self.box.fetch(update_check=False)
+                self.box.fetch(update_check=True)
 
     @patch('kiwi_boxed_plugin.box_download.Command.run')
     @patch('kiwi_boxed_plugin.box_download.Uri')
@@ -117,7 +117,7 @@ class TestBoxDownload:
         mock_Checksum.return_value = checksum
         with patch('builtins.open', create=True):
             with raises(KiwiBoxPluginChecksumError):
-                self.box.fetch(update_check=False)
+                self.box.fetch(update_check=True)
 
     @patch('kiwi_boxed_plugin.box_download.Command.run')
     @patch('kiwi_boxed_plugin.box_download.Uri')


### PR DESCRIPTION
Only apply this check if update check and VM snapshot is enabled. If --no-snapshot is set the system box file is allowed to be modified and the signature check will then always fail