### PR TITLE
Support architecture flag for container builds

### DIFF
--- a/kiwi_boxed_plugin/box_container_build.py
+++ b/kiwi_boxed_plugin/box_container_build.py
@@ -129,6 +129,9 @@ class BoxContainerBuild:
             '--volume', f'{desc}:/description',
             '--volume', '/dev:/dev'
         ]
+        if self.arch:
+            container_run.append('--arch')
+            container_run.append(self.arch)
         if custom_shared_path:
             container_run.append('--volume')
             container_run.append(f'{custom_shared_path}:{custom_shared_path}')

--- a/kiwi_boxed_plugin/box_download.py
+++ b/kiwi_boxed_plugin/box_download.py
@@ -77,8 +77,12 @@ class BoxDownload:
         container_source = self.box_config.get_box_container()
         if container_source:
             container_pull = [
-                'sudo', 'podman', 'pull', container_source
+                'sudo', 'podman', 'pull'
             ]
+            if self.arch:
+                container_pull.append('--arch')
+                container_pull.append(self.arch)
+            container_pull.append(container_source)
             os.system(
                 ' '.join(container_pull)
             )

--- a/test/unit/box_containerbuild_test.py
+++ b/test/unit/box_containerbuild_test.py
@@ -164,6 +164,7 @@ class TestBoxContainerBuild:
             '--volume target:/bundle '
             '--volume desc:/description '
             '--volume /dev:/dev '
+            '--arch x86_64 '
             '--volume /var/tmp/repos:/var/tmp/repos '
             'some'
         )

--- a/test/unit/box_download_test.py
+++ b/test/unit/box_download_test.py
@@ -261,4 +261,6 @@ class TestBoxDownload:
     @patch('os.system')
     def test_fetch_container(self, mock_os_system):
         assert self.box.fetch_container() == 'some'
-        mock_os_system.assert_called_once_with('sudo podman pull some')
+        mock_os_system.assert_called_once_with(
+            'sudo podman pull --arch x86_64 some'
+        )


### PR DESCRIPTION
Cross container builds requires to fetch binfmts like this: sudo podman run --rm --privileged docker.io/multiarch/qemu-user-static --reset -p yes