### PR TITLE
Hand over --kiwi-file option

### DIFF
--- a/kiwi_boxed_plugin/tasks/system_boxbuild.py
+++ b/kiwi_boxed_plugin/tasks/system_boxbuild.py
@@ -260,6 +260,9 @@ class SystemBoxbuildTask(CliTask):
             for profile in sorted(set(self.global_args.get('--profile'))):
                 final_kiwi_build_command.append('--profile')
                 final_kiwi_build_command.append(profile)
+        if self.global_args.get('--kiwi-file'):
+            final_kiwi_build_command.append('--kiwi-file')
+            final_kiwi_build_command.append(self.global_args.get('--kiwi-file'))
         final_kiwi_build_command += kiwi_build_command
         log.info(
             'Building with:{0}    {1}'.format(

--- a/test/unit/tasks/system_boxbuild_test.py
+++ b/test/unit/tasks/system_boxbuild_test.py
@@ -10,7 +10,10 @@ class TestSystemBoxbuildTask:
     def setup(self):
         sys.argv = [
             sys.argv[0],
-            '--debug', '--profile', 'foo', '--type', 'oem',
+            '--debug',
+            '--profile', 'foo',
+            '--type', 'oem',
+            '--kiwi-file', 'appliance.kiwi',
             'system', 'boxbuild',
             '--box', 'universal',
             '--box-memory', '4',
@@ -84,7 +87,10 @@ class TestSystemBoxbuildTask:
         )
         box_containerbuild.run.assert_called_once_with(
             [
-                '--debug', '--type', 'oem', '--profile', 'foo',
+                '--debug',
+                '--type', 'oem',
+                '--profile', 'foo',
+                '--kiwi-file', 'appliance.kiwi',
                 'system', 'build',
                 '--description', 'foo', '--target-dir', 'xxx',
                 '--allow-existing-root',
@@ -107,7 +113,10 @@ class TestSystemBoxbuildTask:
         )
         box_build.run.assert_called_once_with(
             [
-                '--debug', '--type', 'oem', '--profile', 'foo',
+                '--debug',
+                '--type', 'oem',
+                '--profile', 'foo',
+                '--kiwi-file', 'appliance.kiwi',
                 'system', 'build',
                 '--description', 'foo', '--target-dir', 'xxx',
                 '--allow-existing-root',


### PR DESCRIPTION
If the --kiwi-file option is set, make sure it will be handed over to the kiwi call inside of the box.
This is related to rhinstaller/anaconda#6511